### PR TITLE
`MetaCortex.addCortex` validate name parameter

### DIFF
--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -173,6 +173,8 @@ class MetaCortex(EventBus):
         '''
         if self.coresbyname.get(name) != None:
             raise DupCortexName(name)
+        if not isinstance(name, basestring):
+            raise NoSuchName("cortex name must be a string")
 
         event = self.fire('meta:cortex:add',name=name,url=url,tags=tags)
         if not event[1].get('allow',True):


### PR DESCRIPTION
Thought I could use an existing cortex instance like so:

```
memcortex = s_cortex.openurl("ram://")
metacortex = s_cortex.MetaCortex()
metacortex.addCortex("test.mem", memcortex)
```

Didn't get any exceptions, but also didn't get any results when I started querying.

I realize this is user error, but some validation might be useful? totally up to you.

Incidentally, I was surprised when I hooked into `meta:cortex:exc` --- I had an infinite loop on my hands, due to the exception handler in `_tryAddCorUrl`. I see why it happens, but I didn't have a good way to stop it besides resetting everything. Something to think about when there's free time.

```
('log', (('meta:cortex:exc', {'name': 'test.mem', 'exc': AttributeError("Cortex instance has no attribute 'find'",)}),), {})
```