### PR TITLE
Get lift/from partially working again.

### DIFF
--- a/synapse/tests/test_swarm_runtime.py
+++ b/synapse/tests/test_swarm_runtime.py
@@ -73,6 +73,17 @@ class SwarmRunTest(SwarmRunBase):
 
         self.assertEqual( len(data), 4 )
 
+        # FIXME: Fails with "IndexError: string index out of range"
+        # answ = tenv.runt.ask('hehe.haha/foo:bar:vvv')
+        # data = answ.get('data')
+
+        # self.assertEqual( len(data), 2 )
+
+        answ = tenv.runt.ask('hehe.haha/foo:bar:vvv="visi"')
+        data = answ.get('data')
+
+        self.assertEqual( len(data), 2 )
+
         tenv.fini()
 
     def test_swarm_runtime_pivot(self):


### PR DESCRIPTION
This gets `from/prop="val"` working again, but `from/prop` still doesn't work.