### PR TITLE
cortex: add subprop values correctly

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -1300,7 +1300,7 @@ class Cortex(EventBus,DataModel):
 
             # any sub-properties to populate?
             for sname,svalu in subs.items():
-                props[ '%s:%s' % (prop,sname) ] = valu
+                props[ '%s:%s' % (prop,sname) ] = svalu
 
             props[prop] = valu
 


### PR DESCRIPTION
fix bug in subprop parsing where the subprop value was incorrectly set to the entire value, not sub value.

i added the test to test_cortex, but not sure if this is the appropriate place. subprop pasing code is in the cortex module, though dealing with handling of types makes me think it could also go in test_datamodel.