### PR TITLE
datamodel: update documentation for getPropType

### DIFF
--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -355,12 +355,11 @@ class DataModel(s_types.TypeLib):
 
     def getPropType(self, prop):
         '''
-        Return the name of the data model type for the given property.
+        Return the data model type instance for the given property, 
+         or None if the data model doesn't have an entry for the property.
 
         Example:
-
             ptype = model.getPropType('foo:bar')
-
         '''
         pdef = self.getPropDef(prop)
         if pdef == None:


### PR DESCRIPTION
documentation indicates that `getPropType()` returns a name (string), but it actually returns the type instance (or None). update the documentation to reflect this.

feel free to close this issue and open a bug that the documentation was correct and the implementation wrong, and i'll take a stab at fixing that.