### PR TITLE
Add atomic max/minTufoProp setters.

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -1437,10 +1437,91 @@ class Cortex(EventBus,DataModel):
         with self.inclock:
             rows = self._getRowsByIdProp(iden,prop)
             if len(rows) == 0:
-                raise NoSuchTufo(repr(tufo))
+                oldv = None
+                valu = incval
+            else:
+                oldv = rows[0][2]
+                valu = oldv + incval
 
-            oldv = rows[0][2]
-            valu = oldv + incval
+            self._setRowsByIdProp(iden,prop,valu)
+
+            tufo[1][prop] = valu
+            self.fire('tufo:set:%s' % (prop,), tufo=tufo, prop=prop, valu=valu, oldv=oldv)
+
+        return tufo
+
+    def maxTufoProp(self, tufo, prop, maxval):
+        '''
+        Atomically set a property to the maximum of its current value (if any) and the given value.
+
+        Example:
+
+            tufo = core.maxTufoProp(tufo,prop,maxval)
+
+        '''
+        form = tufo[1].get('tufo:form')
+        prop = '%s:%s' % (form,prop)
+
+        if not self._okSetProp(prop):
+            return tufo
+
+        return self._maxTufoProp(tufo,prop,maxval)
+
+    def _maxTufoProp(self, tufo, prop, maxval):
+
+        # to allow storage layer optimization
+        iden = tufo[0]
+
+        with self.inclock:
+            rows = self._getRowsByIdProp(iden,prop)
+            if len(rows) == 0:
+                oldv = None
+                valu = maxval
+            else:
+                oldv = rows[0][2]
+                valu = max(oldv,maxval)
+                if oldv == valu:
+                    return tufo
+
+            self._setRowsByIdProp(iden,prop,valu)
+
+            tufo[1][prop] = valu
+            self.fire('tufo:set:%s' % (prop,), tufo=tufo, prop=prop, valu=valu, oldv=oldv)
+
+        return tufo
+
+    def minTufoProp(self, tufo, prop, minval):
+        '''
+        Atomically set a property to the minimum of its current value (if any) and the given value.
+
+        Example:
+
+            tufo = core.minTufoProp(tufo,prop,minval)
+
+        '''
+        form = tufo[1].get('tufo:form')
+        prop = '%s:%s' % (form,prop)
+
+        if not self._okSetProp(prop):
+            return tufo
+
+        return self._minTufoProp(tufo,prop,minval)
+
+    def _minTufoProp(self, tufo, prop, minval):
+
+        # to allow storage layer optimization
+        iden = tufo[0]
+
+        with self.inclock:
+            rows = self._getRowsByIdProp(iden,prop)
+            if len(rows) == 0:
+                oldv = None
+                valu = minval
+            else:
+                oldv = rows[0][2]
+                valu = min(oldv,minval)
+                if oldv == valu:
+                    return tufo
 
             self._setRowsByIdProp(iden,prop,valu)
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -148,7 +148,6 @@ class CortexTest(SynTest):
         def formfqdn(event):
             fqdn = event[1].get('valu')
             event[1]['props']['tld'] = fqdn.split('.')[-1]
-            event[1]['props']['fqdn:inctest'] = 0
 
         core.on('tufo:form', formtufo)
         core.on('tufo:form:fqdn', formfqdn)
@@ -158,15 +157,38 @@ class CortexTest(SynTest):
         self.assertEqual( tufo[1].get('tld'), 'com')
         self.assertEqual( tufo[1].get('woot'), 'woot')
 
-        self.assertEqual( tufo[1].get('fqdn:inctest'), 0)
+        # Test incTufoProp
+        self.assertEqual( tufo[1].get('fqdn:inctest'), None )
 
         tufo = core.incTufoProp(tufo, 'inctest')
-
         self.assertEqual( tufo[1].get('fqdn:inctest'), 1 )
 
         tufo = core.incTufoProp(tufo, 'inctest', incval=-1)
-
         self.assertEqual( tufo[1].get('fqdn:inctest'), 0 )
+
+        # Test maxTufoProp
+        self.assertEqual(tufo[1].get('fqdn:maxtest'), None)
+
+        tufo = core.maxTufoProp(tufo, 'maxtest', 0)
+        self.assertEqual(tufo[1].get('fqdn:maxtest'), 0)
+
+        tufo = core.maxTufoProp(tufo, 'maxtest', 20)
+        self.assertEqual(tufo[1].get('fqdn:maxtest'), 20)
+
+        tufo = core.maxTufoProp(tufo, 'maxtest', 10)
+        self.assertEqual(tufo[1].get('fqdn:maxtest'), 20)
+
+        # Test minTufoProp
+        self.assertEqual(tufo[1].get('fqdn:mintest'), None)
+
+        tufo = core.minTufoProp(tufo, 'mintest', 0)
+        self.assertEqual(tufo[1].get('fqdn:mintest'), 0)
+
+        tufo = core.minTufoProp(tufo, 'mintest', -20)
+        self.assertEqual(tufo[1].get('fqdn:mintest'), -20)
+
+        tufo = core.minTufoProp(tufo, 'mintest', -10)
+        self.assertEqual(tufo[1].get('fqdn:mintest'), -20)
 
         core.fini()
 


### PR DESCRIPTION
Also a small change to incTufoProp to stop throwing NoSuchTufo and default to zero. I considered checking the prop def for a defval, but decided to keep it simple for now. Same goes for the copy pasta boilerplate atomic set code.