### PR TITLE
Don't configure postgres.

### DIFF
--- a/synapse/cores/postgres.py
+++ b/synapse/cores/postgres.py
@@ -35,9 +35,6 @@ class Cortex(s_c_sqlite.Cortex):
 
                 time.sleep(1)
 
-        c = db.cursor()
-        c.execute('SET enable_seqscan=false')
-        c.close()
         return db
 
     def _getTableName(self):


### PR DESCRIPTION
I'm doing a lot of performance tuning on RDS/EC2 right now and enable_seqscan=false has a negative impact for me. Let's keep database tuning out of synapse.

TLDR: enable_seqscan=on 20% faster than off for my AWS setup

```
flashdb=> set enable_seqscan=on;
SET
flashdb=> explain analyze SELECT * FROM flash_hostfile WHERE id IN (SELECT id FROM flash_hostfile WHERE prop='hostFile');
                                                                            QUERY PLAN                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Hash Join  (cost=6663.25..16825.62 rows=315057 width=132) (actual time=53.768..275.513 rows=324169 loops=1)
   Hash Cond: ((flash_hostfile.id)::text = (flash_hostfile_1.id)::text)
   ->  Seq Scan on flash_hostfile  (cost=0.00..8711.72 rows=324172 width=132) (actual time=0.010..62.091 rows=324172 loops=1)
   ->  Hash  (cost=6643.10..6643.10 rows=1612 width=33) (actual time=53.724..53.724 rows=23156 loops=1)
         Buckets: 32768 (originally 2048)  Batches: 1 (originally 1)  Memory Usage: 1726kB
         ->  HashAggregate  (cost=6626.98..6643.10 rows=1612 width=33) (actual time=40.914..46.778 rows=23156 loops=1)
               Group Key: (flash_hostfile_1.id)::text
               ->  Bitmap Heap Scan on flash_hostfile flash_hostfile_1  (cost=819.03..6570.65 rows=22530 width=33) (actual time=3.974..29.519 rows=23156 loops=1)
                     Recheck Cond: ((prop)::text = 'hostFile'::text)
                     Heap Blocks: exact=5470
                     ->  Bitmap Index Scan on flash_hostfile_intval_idx  (cost=0.00..813.40 rows=22530 width=0) (actual time=3.155..3.155 rows=23156 loops=1)
                           Index Cond: ((prop)::text = 'hostFile'::text)
 Planning time: 0.793 ms
 Execution time: 314.070 ms
(14 rows)

flashdb=> SELECT * FROM flash_hostfile WHERE id IN (SELECT id FROM flash_hostfile WHERE prop='hostFile');
Time: 642.641 ms
flashdb=> SELECT * FROM flash_hostfile WHERE id IN (SELECT id FROM flash_hostfile WHERE prop='hostFile');
Time: 647.612 ms
flashdb=> SELECT * FROM flash_hostfile WHERE id IN (SELECT id FROM flash_hostfile WHERE prop='hostFile');
Time: 639.852 ms
flashdb=> SELECT * FROM flash_hostfile WHERE id IN (SELECT id FROM flash_hostfile WHERE prop='hostFile');
Time: 645.347 ms
```

```
flashdb=> set enable_seqscan=off;
SET
Time: 0.237 ms
flashdb=> explain analyze SELECT * FROM flash_hostfile WHERE id IN (SELECT id FROM flash_hostfile WHERE prop='hostFile');
                                                                         QUERY PLAN                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=6627.40..34940.75 rows=315057 width=132) (actual time=24.643..433.260 rows=324169 loops=1)
   ->  HashAggregate  (cost=6626.98..6643.10 rows=1612 width=33) (actual time=24.570..33.857 rows=23156 loops=1)
         Group Key: (flash_hostfile_1.id)::text
         ->  Bitmap Heap Scan on flash_hostfile flash_hostfile_1  (cost=819.03..6570.65 rows=22530 width=33) (actual time=3.155..14.853 rows=23156 loops=1)
               Recheck Cond: ((prop)::text = 'hostFile'::text)
               Heap Blocks: exact=5470
               ->  Bitmap Index Scan on flash_hostfile_intval_idx  (cost=0.00..813.40 rows=22530 width=0) (actual time=2.350..2.350 rows=23156 loops=1)
                     Index Cond: ((prop)::text = 'hostFile'::text)
   ->  Index Scan using flash_hostfile_id_idx on flash_hostfile  (cost=0.42..17.41 rows=14 width=132) (actual time=0.008..0.012 rows=14 loops=23156)
         Index Cond: ((id)::text = (flash_hostfile_1.id)::text)
 Planning time: 0.475 ms
 Execution time: 472.113 ms
(12 rows)

flashdb=> SELECT * FROM flash_hostfile WHERE id IN (SELECT id FROM flash_hostfile WHERE prop='hostFile');
Time: 813.030 ms
flashdb=> SELECT * FROM flash_hostfile WHERE id IN (SELECT id FROM flash_hostfile WHERE prop='hostFile');
Time: 816.407 ms
flashdb=> SELECT * FROM flash_hostfile WHERE id IN (SELECT id FROM flash_hostfile WHERE prop='hostFile');
Time: 816.548 ms
flashdb=> SELECT * FROM flash_hostfile WHERE id IN (SELECT id FROM flash_hostfile WHERE prop='hostFile');
Time: 819.240 ms
```