### PR TITLE
Replace TestWaiter with eventbus.Waiter

### DIFF
--- a/synapse/tests/common.py
+++ b/synapse/tests/common.py
@@ -8,6 +8,7 @@ import contextlib
 
 logging.basicConfig(level=logging.WARNING)
 
+from synapse.eventbus import Waiter
 import synapse.lib.thishost as s_thishost
 
 from synapse.common import *
@@ -40,36 +41,11 @@ class TestEnv:
         for bus in self.tofini:
             bus.fini()
 
-class TestWaiter:
-
-    def __init__(self, bus, size, *evts):
-        self.evts = evts
-        self.size = size
-        self.events = []
-
-        self.event = threading.Event()
-
-        for evt in evts:
-            bus.on(evt, self._onTestEvent)
-
-        if not evts:
-            bus.link(self._onTestEvent)
-
-    def _onTestEvent(self, event):
-        self.events.append(event)
-        if len(self.events) >= self.size:
-            self.event.set()
-
-    def wait(self, timeout=3):
-        self.event.wait(timeout=timeout)
-        if len(self.events) < self.size:
-            raise TooFewEvents('%r: %d/%d' % (self.evts, len(self.events), self.size))
-        return self.events
 
 class SynTest(unittest.TestCase):
 
     def getTestWait(self, bus, size, *evts):
-        return TestWaiter(bus, size, *evts)
+        return Waiter(bus, size, *evts)
 
     def thisHostMust(self, **props):
         for k,v in props.items():

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1,14 +1,11 @@
+
 import os
-import logging
-import binascii
 import unittest
 
 import synapse.link as s_link
 import synapse.compat as s_compat
 import synapse.common as s_common
 import synapse.cortex as s_cortex
-import synapse.daemon as s_daemon
-import synapse.telepath as s_telepath
 
 import synapse.lib.tags as s_tags
 import synapse.lib.types as s_types
@@ -534,11 +531,11 @@ class CortexTest(SynTest):
 
         hehe = core.formTufoByProp('foo','hehe')
 
-        wait = TestWaiter(core, 2, 'tufo:tag:add')
+        wait = self.getTestWait(core, 2, 'tufo:tag:add')
         core.addTufoTag(hehe,'lulz.rofl')
         wait.wait()
 
-        wait = TestWaiter(core, 1, 'tufo:tag:add')
+        wait = self.getTestWait(core, 1, 'tufo:tag:add')
         core.addTufoTag(hehe,'lulz.rofl.zebr')
         wait.wait()
 
@@ -557,11 +554,11 @@ class CortexTest(SynTest):
 
         self.assertEqual( rofl[1].get('syn:tag:depth'), 1 )
 
-        wait = TestWaiter(core, 2, 'tufo:tag:del')
+        wait = self.getTestWait(core, 2, 'tufo:tag:del')
         core.delTufoTag(hehe,'lulz.rofl')
         wait.wait()
 
-        wait = TestWaiter(core, 1, 'tufo:tag:del')
+        wait = self.getTestWait(core, 1, 'tufo:tag:del')
         core.delTufo(lulz)
         wait.wait()
         # tag and subs should be wiped

--- a/synapse/tests/test_neuron.py
+++ b/synapse/tests/test_neuron.py
@@ -335,11 +335,11 @@ class TempDisabled:
         env.add('neup1', s_telepath.openurl('tcp://127.0.0.1/neu1', port=port), fini=True)
         env.add('neup2', s_telepath.openurl('tcp://127.0.0.1/neu2', port=port), fini=True)
 
-        wai0 = TestWaiter(env.neu1, 1, 'neu:link:init')
+        wai0 = self.getTestWait(env.neu1, 1, 'neu:link:init')
         env.neu0.link( env.neup1 )
         wai0.wait()
 
-        wai0 = TestWaiter(env.neu1, 1, 'neu:link:init')
+        wai0 = self.getTestWait(env.neu1, 1, 'neu:link:init')
         env.neu0.link( env.neup2 )
         wai0.wait()
 
@@ -354,7 +354,7 @@ class TempDisabled:
         neu0.link( neu1 )
         neu0.link( neu2 )
 
-        wait0 = TestWaiter(neu1, 1, 'woot')
+        wait0 = self.getTestWait(neu1, 1, 'woot')
         neu2.route( neu1.getIden(), 'woot', x=10)
 
         events = wait0.wait()
@@ -373,7 +373,7 @@ class TempDisabled:
         neu0.link( neu1 )
         neu0.link( neu2 )
 
-        wai0 = TestWaiter(neu1, 1, 'woot')
+        wai0 = self.getTestWait(neu1, 1, 'woot')
 
         neu2.storm('woot', x=10)
 

--- a/synapse/tests/test_threads.py
+++ b/synapse/tests/test_threads.py
@@ -27,7 +27,7 @@ class ThreadsTest(unittest.TestCase):
 
         pool = s_threads.Pool()
 
-        wait = TestWaiter( pool, 1, 'pool:work:fini' )
+        wait = s_eventbus.Waiter( pool, 1, 'pool:work:fini' )
 
         def woot(x,y):
             return x + y
@@ -41,7 +41,7 @@ class ThreadsTest(unittest.TestCase):
 
         pool = s_threads.Pool()
 
-        wait = TestWaiter( pool, 1, 'pool:work:fini' )
+        wait = s_eventbus.Waiter( pool, 1, 'pool:work:fini' )
 
         def woot(x,y):
             return x + y


### PR DESCRIPTION
Deletes some redundant code and silences 35 pytest warnings.