### PR TITLE
cortex: clarify range inclusivity via test

### DIFF
--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -178,6 +178,11 @@ class CortexTest(SynTest):
 
         self.assertEqual( core.getSizeBy('range','rg',(0,20)), 1 )
         self.assertEqual( core.getRowsBy('range','rg',(0,20))[0][2], 10 )
+        
+        # range is inclusive of `min`, exclusive of `max`
+        self.assertEqual( core.getSizeBy('range','rg',(9,11)), 1 )
+        self.assertEqual( core.getSizeBy('range','rg',(10,12)), 1 )
+        self.assertEqual( core.getSizeBy('range','rg',(8,10)), 0 )
 
         self.assertEqual( core.getSizeBy('ge','rg',20), 1 )
         self.assertEqual( core.getRowsBy('ge','rg',20)[0][2], 30)


### PR DESCRIPTION
im basing this intent off the ram cortex implementation:

https://github.com/vivisect/synapse/blob/e3834f4845a0d69e015844bab7031e1d3a670940/synapse/cores/ram.py#L27