### PR TITLE
persist typelib and datamodel metadata in the cortex

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -47,8 +47,6 @@ class Cortex(EventBus,DataModel,ConfigMixin):
     '''
     def __init__(self, link):
         EventBus.__init__(self)
-        DataModel.__init__(self)
-
         ConfigMixin.__init__(self)
 
         self.addConfDef('enforce',type='bool',asloc='enforce',defval=0,doc='Enables data model enforcement')
@@ -125,9 +123,7 @@ class Cortex(EventBus,DataModel,ConfigMixin):
         self.addStatFunc('average',self._calcStatAverage)
 
         self._initCortex()
-
-        self.addDefaultTypes()
-        self.bootstrapForms()
+        DataModel.__init__(self)
 
         # TODO: syn:err with rate limiting?
 

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -125,6 +125,8 @@ class Cortex(EventBus,DataModel,ConfigMixin):
 
         self._initCortex()
 
+        self.addDefaultTypes()
+
         # FIXME unicode / "word" characters
         #self.addSubType('syn:tag','str', regex='^[a-z0-9._]+$', lower=1)
         #self.addSubType('syn:prop','str', regex='^[a-z0-9:_]+$', lower=1)

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -1968,12 +1968,18 @@ class Cortex(EventBus,DataModel,ConfigMixin):
         defval = info.get('defval')
         ptype = info.get('ptype')
 
-        del info['form']
-        self.formTufoByFrob('syn:prop', prop, **info)
+        # `form` is the name of a paramter to `formTufoByFrob`,
+        #   so we have to set it separately
+        form = info.pop('form')
+        tufo = self.formTufoByFrob('syn:prop', prop, **info)
+        self.setTufoProp(tufo, 'form', form)
 
     # overrides: synapse.datamodel.DataModel.addPropGlob
     def addPropGlob(self, glob, **info):
         DataModel.addPropGlob(self, glob, **info)
 
-        del info['form']
-        self.formTufoByFrob('syn:prop:glob', glob, **info)
+        # `form` is the name of a paramter to `formTufoByFrob`,
+        #   so we have to set it separately
+        form = info.pop('form')
+        tufo = self.formTufoByFrob('syn:prop:glob', glob, **info)
+        self.setTufoProp(tufo, 'form', form)

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -1919,12 +1919,12 @@ class Cortex(EventBus,DataModel,ConfigMixin):
     # overrides: synapse.lib.types.TypeLib.addType
     def addType(self, typ):
         s_types.TypeLib.addType(self, typ)
-        self.formTufoByProp('syn:type', typ.name)
+        self.formTufoByFrob('syn:type', typ.name)
 
     # overrides: synapse.lib.types.TypeLib.addSubType
     def addSubType(self, name, subof, **info):
         s_types.TypeLib.addSubType(self, name, subof, **info)
-        base = self.getTufoByProp('syn:type', subof)
+        base = self.getTufoByFrob('syn:type', subof)
 
         subinfo = {}
         for propname, propval in base[1].items():
@@ -1941,5 +1941,6 @@ class Cortex(EventBus,DataModel,ConfigMixin):
         # TypeLib.addSubType calls TypeLib.addType, so our subtype tufo already exists,
         #  but we still need to add the subtype-specific fields
         sub = self.getTufoByProp('syn:type', name)
+        subinfo = self._frobTufoProps('syn:type', subinfo)
         self.setTufoProps(sub, **subinfo)
 

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -127,38 +127,9 @@ class Cortex(EventBus,DataModel,ConfigMixin):
         self._initCortex()
 
         self.addDefaultTypes()
-
-        # FIXME unicode / "word" characters
-        #self.addSubType('syn:tag','str', regex='^[a-z0-9._]+$', lower=1)
-        #self.addSubType('syn:prop','str', regex='^[a-z0-9:_]+$', lower=1)
-        #self.addSubType('syn:type','str', regex='^[a-z0-9:_]+$', lower=1)
-
-        self.addTufoForm('syn:tag', ptype='syn:tag')
-        self.addTufoProp('syn:tag','up',ptype='syn:tag')
-        self.addTufoProp('syn:tag','doc',defval='',ptype='str')
-        self.addTufoProp('syn:tag','depth',defval=0,ptype='int')
-        self.addTufoProp('syn:tag','title',defval='',ptype='str')
-
-        self.addTufoForm('syn:model',ptype='syn:prop', doc='prefix for all forms within the model')
-        self.addTufoForm('syn:model:version', ptype='int', doc='model version for the model loaded in the cortex')
-
-        self.addTufoForm('syn:type',ptype='syn:type')
-        self.addTufoProp('syn:type','doc',ptype='str', defval='??', doc='Description for this type')
-        self.addTufoProp('syn:type','ver',ptype='int', defval=1, doc='What version is this type')
-        self.addTufoProp('syn:type','base',ptype='str', doc='what type does this type extend?', req=True)
-        self.addTufoGlob('syn:type','info:*')
-
-        self.addTufoForm('syn:form',ptype='syn:prop')
-        self.addTufoProp('syn:form','doc',ptype='str', doc='basic form definition')
-        self.addTufoProp('syn:form','ver',ptype='int', doc='form version within the model')
-        self.addTufoProp('syn:form','model',ptype='str', doc='which model defines a given form')
+        self.bootstrapForms()
 
         # TODO: syn:err with rate limiting?
-
-        self.addTufoForm('syn:prop',ptype='syn:prop')
-        self.addTufoProp('syn:prop','doc',ptype='str')
-        self.addTufoProp('syn:prop','form',ptype='syn:prop')
-        self.addTufoProp('syn:prop','ptype',ptype='syn:type')
 
         self.addTufoForm('syn:core')
         self.addTufoProp('syn:core','url', ptype='inet:url')

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -1938,6 +1938,13 @@ class Cortex(EventBus,DataModel,ConfigMixin):
 
         subinfo['base'] = subof
 
+        if 'fields' in subinfo:
+            fields = subinfo.pop('fields')
+            subinfo['fields'] = len(fields)
+            for i, (fieldname, fieldtype) in enumerate(fields):
+                k = 'field:%d:%s' % (i, fieldname)
+                subinfo[k] = fieldtype
+
         # TypeLib.addSubType calls TypeLib.addType, so our subtype tufo already exists,
         #  but we still need to add the subtype-specific fields
         sub = self.getTufoByProp('syn:type', name)

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -1951,3 +1951,29 @@ class Cortex(EventBus,DataModel,ConfigMixin):
         subinfo = self._frobTufoProps('syn:type', subinfo)
         self.setTufoProps(sub, **subinfo)
 
+    #############################################################
+    # support datamodel persistence
+    #############################################################
+
+    # overrides: synapse.datamodel.DataModel.addTufoForm
+    def addTufoForm(self, form, **info):
+        DataModel.addTufoForm(self, form, **info)
+        self.formTufoByFrob('syn:form', form, **info)
+
+    # overrides: synapse.datamodel.DataModel.addPropDef
+    def addPropDef(self, prop, **info):
+        DataModel.addPropDef(self, prop, **info)
+
+        form = info.get('form')
+        defval = info.get('defval')
+        ptype = info.get('ptype')
+
+        del info['form']
+        self.formTufoByFrob('syn:prop', prop, **info)
+
+    # overrides: synapse.datamodel.DataModel.addPropGlob
+    def addPropGlob(self, glob, **info):
+        DataModel.addPropGlob(self, glob, **info)
+
+        del info['form']
+        self.formTufoByFrob('syn:prop:glob', glob, **info)

--- a/synapse/cores/sqlite.py
+++ b/synapse/cores/sqlite.py
@@ -504,7 +504,7 @@ class Cortex(common.Cortex):
                 ret.append( (ident,prop,intval,stamp) )
             else:
                 ret.append( (ident,prop,strval,stamp) )
-                
+
         return ret
 
     def _getRowsById(self, ident):

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -23,7 +23,6 @@ def propdef(name, **info):
     return (name,info)
 
 tlib = s_types.TypeLib()
-tlib.addDefaultTypes()
 def getTypeRepr(name, valu):
     '''
     '''
@@ -90,8 +89,6 @@ def parsetypes(*atypes, **kwtypes):
 class DataModel(s_types.TypeLib):
 
     def __init__(self):
-        s_types.TypeLib.__init__(self)
-
         self.props = {}
         self.forms = set()
 
@@ -109,10 +106,8 @@ class DataModel(s_types.TypeLib):
             'forms':[],
         }
 
-    def bootstrapForms(self):
-        '''
-        Initialize the DataModel with the forms that describe itself.
-        '''
+        s_types.TypeLib.__init__(self)
+
         self.addSubType('syn:tag','str', regex=r'^([\w]+\.)*[\w]+$', lower=1)
         self.addSubType('syn:prop','str', regex=r'^([\w]+:)*[\w]+$', lower=1)
         self.addSubType('syn:prop:glob','str', regex=r'^([\w]+:)*[\w]+:\*$', lower=1)

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -128,6 +128,7 @@ class DataModel(s_types.TypeLib):
         self.addTufoProp('syn:prop','doc',ptype='str')
         self.addTufoProp('syn:prop','form',ptype='syn:prop')
         self.addTufoProp('syn:prop','ptype',ptype='syn:type')
+        self.addTufoProp('syn:prop','req',ptype='bool')
 
         self.addTufoForm('syn:prop:glob',ptype='syn:prop:glob')
         self.addTufoProp('syn:prop:glob','doc',ptype='str')

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -23,6 +23,7 @@ def propdef(name, **info):
     return (name,info)
 
 tlib = s_types.TypeLib()
+tlib.addDefaultTypes()
 def getTypeRepr(name, valu):
     '''
     '''

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -113,7 +113,6 @@ class DataModel(s_types.TypeLib):
         '''
         Initialize the DataModel with the forms that describe itself.
         '''
-
         self.addSubType('syn:tag','str', regex=r'^([\w]+\.)*[\w]+$', lower=1)
         self.addSubType('syn:prop','str', regex=r'^([\w]+:)*[\w]+$', lower=1)
         self.addSubType('syn:prop:glob','str', regex=r'^([\w]+:)*[\w]+:\*$', lower=1)

--- a/synapse/datamodel.py
+++ b/synapse/datamodel.py
@@ -109,6 +109,48 @@ class DataModel(s_types.TypeLib):
             'forms':[],
         }
 
+    def bootstrapForms(self):
+        '''
+        Initialize the DataModel with the forms that describe itself.
+        '''
+
+        self.addSubType('syn:tag','str', regex=r'^([\w]+\.)*[\w]+$', lower=1)
+        self.addSubType('syn:prop','str', regex=r'^([\w]+:)*[\w]+$', lower=1)
+        self.addSubType('syn:prop:glob','str', regex=r'^([\w]+:)*[\w]+:\*$', lower=1)
+        self.addSubType('syn:type','str', regex=r'^([\w]+:)*[\w]+$', lower=1)
+
+        self.addTufoForm('syn:form',ptype='syn:prop')
+        self.addTufoProp('syn:form','doc',ptype='str', doc='basic form definition')
+        self.addTufoProp('syn:form','ver',ptype='int', doc='form version within the model')
+        self.addTufoProp('syn:form','model',ptype='str', doc='which model defines a given form')
+
+        self.addTufoForm('syn:prop',ptype='syn:prop')
+        self.addTufoProp('syn:prop','doc',ptype='str')
+        self.addTufoProp('syn:prop','form',ptype='syn:prop')
+        self.addTufoProp('syn:prop','ptype',ptype='syn:type')
+
+        self.addTufoForm('syn:prop:glob',ptype='syn:prop:glob')
+        self.addTufoProp('syn:prop:glob','doc',ptype='str')
+        self.addTufoProp('syn:prop:glob','form',ptype='syn:prop')
+        self.addTufoProp('syn:prop:glob','ptype',ptype='syn:type')
+
+        self.addTufoForm('syn:tag', ptype='syn:tag')
+        self.addTufoProp('syn:tag','up',ptype='syn:tag')
+        self.addTufoProp('syn:tag','doc',defval='',ptype='str')
+        self.addTufoProp('syn:tag','depth',defval=0,ptype='int')
+        self.addTufoProp('syn:tag','title',defval='',ptype='str')
+
+        self.addTufoForm('syn:model',ptype='syn:prop', doc='prefix for all forms within the model')
+        self.addTufoForm('syn:model:version', ptype='int', doc='model version for the model loaded in the cortex')
+
+        self.addTufoForm('syn:type',ptype='syn:type')
+        self.addTufoProp('syn:type','doc',ptype='str', defval='??', doc='Description for this type')
+        self.addTufoProp('syn:type','ver',ptype='int', defval=1, doc='What version is this type')
+        self.addTufoProp('syn:type','base',ptype='str', doc='what type does this type extend?', req=1)
+        self.addTufoProp('syn:type','fields',ptype='int',doc='number of fields for composite type')
+        self.addTufoGlob('syn:type','field:*',ptype='str',doc='field in composite type')
+        self.addTufoGlob('syn:type','info:*')
+
     def getModelDict(self):
         '''
         Returns a dictionary which represents the data model.

--- a/synapse/lib/config.py
+++ b/synapse/lib/config.py
@@ -52,7 +52,7 @@ class ConfigMixin:
             self._conf_defs[name] = (name,dict(info))
 
     def reqConfOk(self, opts):
-        ''' 
+        '''
         Check that that config values pass validation or raise.
         '''
         for name,valu in opts.items():

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -561,10 +561,6 @@ class TypeLib:
         self.addSubType('int:min','int', ismin=1)
         self.addSubType('int:max','int', ismax=1)
 
-        self.addSubType('syn:tag','str', regex=r'^([\w]+\.)*[\w]+$', lower=1)
-        self.addSubType('syn:prop','str', regex=r'^([\w]+:)*[\w]+$', lower=1)
-        self.addSubType('syn:type','str', regex=r'^([\w]+:)*[\w]+$', lower=1)
-
         self.addSubType('text', 'str')
 
         self.addSubType('str:lwr', 'str', lower=1)

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -552,6 +552,7 @@ class TypeLib:
         self.types = {}
         self.subtypes = []
 
+    def addDefaultTypes(self):
         self.addType(IntType(self,'int'))
         self.addType(StrType(self,'str'))
         self.addType(BoolType(self,'bool'))

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -552,7 +552,6 @@ class TypeLib:
         self.types = {}
         self.subtypes = []
 
-    def addDefaultTypes(self):
         self.addType(IntType(self,'int'))
         self.addType(StrType(self,'str'))
         self.addType(BoolType(self,'bool'))

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -282,7 +282,6 @@ class CortexTest(SynTest):
 
         # BY CIDR
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         ipint = tlib.getTypeParse('inet:ipv4', '192.168.0.1')
         ipa = core.formTufoByProp('inet:ipv4', ipint)

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1148,3 +1148,17 @@ class CortexTest(SynTest):
     def test_cortex_reqstor(self):
         with s_cortex.openurl('ram://') as core:
             self.assertRaises( BadPropValu, core.formTufoByProp, 'foo:bar', True )
+
+    def test_cortex_tlib_persistence(self):
+        with s_cortex.openurl('ram://') as core:
+            inttype = core.getTufoByProp('syn:type', 'int')
+            self.assertIsNotNone( inttype )
+
+            strtype = core.getTufoByProp('syn:type', 'str')
+            self.assertIsNotNone( strtype )
+
+            intmintype = core.getTufoByProp('syn:type', 'int:min')
+            self.assertIsNotNone( intmintype )
+            self.assertEqual( intmintype[1].get('syn:type:base'), 'int' )
+            self.assertEqual( intmintype[1].get('syn:type:ismin'), 1 )
+

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1170,3 +1170,25 @@ class CortexTest(SynTest):
             self.assertEqual( dnstype[1].get('syn:type:field:1:ipv4'), 'inet:ipv4' )
             self.assertEqual( dnstype[1].get('syn:type:field:2:time'), 'time:epoch' )
 
+    def test_cortex_datamodel_persistence(self):
+        with s_cortex.openurl('ram://') as core:
+            self.assertIsNotNone( core.getTufoByProp('syn:form', 'syn:form') )
+
+            core.addTufoForm('foo', doc='ddd')
+            fooform = core.getTufoByProp('syn:form', 'foo')
+            self.assertIsNotNone( fooform )
+            self.assertEqual( fooform[1].get('syn:form:doc'), 'ddd' )
+
+            core.addTufoProp('foo', 'bar')
+            foobarprop = core.getTufoByProp('syn:prop', 'foo:bar')
+            self.assertIsNotNone(foobarprop)
+
+            core.addTufoProp('foo', 'baz', ptype='str')
+            foobazprop = core.getTufoByProp('syn:prop', 'foo:baz')
+            self.assertIsNotNone(foobazprop)
+            self.assertEqual(foobazprop[1].get('syn:prop:ptype'), 'str')
+
+            core.addTufoGlob('foo', 'yaz:*', ptype='int')
+            fooyazprop = core.getTufoByProp('syn:prop:glob', 'foo:yaz:*')
+            self.assertIsNotNone(fooyazprop)
+            self.assertEqual(fooyazprop[1].get('syn:prop:glob:ptype'), 'int')

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1162,3 +1162,11 @@ class CortexTest(SynTest):
             self.assertEqual( intmintype[1].get('syn:type:base'), 'int' )
             self.assertEqual( intmintype[1].get('syn:type:ismin'), 1 )
 
+            fields = (('fqdn','inet:fqdn'),('ipv4','inet:ipv4'),('time','time:epoch'))
+            core.addSubType('dns:a','comp',fields=fields)
+            dnstype = core.getTufoByProp('syn:type', 'dns:a')
+            self.assertEqual( dnstype[1].get('syn:type:fields'), 3 )
+            self.assertEqual( dnstype[1].get('syn:type:field:0:fqdn'), 'inet:fqdn' )
+            self.assertEqual( dnstype[1].get('syn:type:field:1:ipv4'), 'inet:ipv4' )
+            self.assertEqual( dnstype[1].get('syn:type:field:2:time'), 'time:epoch' )
+

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -282,6 +282,7 @@ class CortexTest(SynTest):
 
         # BY CIDR
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         ipint = tlib.getTypeParse('inet:ipv4', '192.168.0.1')
         ipa = core.formTufoByProp('inet:ipv4', ipint)

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -9,6 +9,8 @@ class DataModelTest(SynTest):
 
     def test_datamodel_types(self):
         model = s_datamodel.DataModel()
+        model.addDefaultTypes()
+
         model.addTufoForm('foo')
         model.addTufoProp('foo', 'bar', ptype='int')
         model.addTufoProp('foo', 'baz', ptype='str')
@@ -32,18 +34,23 @@ class DataModelTest(SynTest):
 
     def test_datamodel_glob(self):
         model = s_datamodel.DataModel()
+        model.addDefaultTypes()
+
         model.addTufoForm('foo')
         model.addPropGlob('foo:bar:*',ptype='str:lwr')
         self.assertEqual( model.getPropNorm('foo:bar:baz','Woot'), 'woot' )
 
     def test_datamodel_fail_notype(self):
         model = s_datamodel.DataModel()
+        model.addDefaultTypes()
 
         model.addTufoForm('foo')
         self.assertRaises( s_datamodel.NoSuchType, model.addTufoProp, 'foo', 'bar', ptype='hehe' )
 
     def test_datamodel_fail_noprop(self):
         model = s_datamodel.DataModel()
+        model.addDefaultTypes()
+
         self.assertRaises( NoSuchForm, model.addTufoProp, 'foo', 'bar' )
 
         model.addTufoForm('foo')
@@ -53,7 +60,6 @@ class DataModelTest(SynTest):
         self.assertRaises( DupPropName, model.addTufoProp, 'foo', 'bar' )
 
     def test_datamodel_cortex(self):
-
         core = s_cortex.openurl('ram:///')
 
         core.addTufoForm('foo')
@@ -84,6 +90,8 @@ class DataModelTest(SynTest):
 
     def test_datamodel_subs(self):
         model = s_datamodel.DataModel()
+        model.addDefaultTypes()
+
         model.addTufoForm('foo')
         model.addTufoProp('foo','bar',ptype='int')
 
@@ -99,6 +107,7 @@ class DataModelTest(SynTest):
 
     def test_datamodel_bool(self):
         model = s_datamodel.DataModel()
+        model.addDefaultTypes()
 
         model.addTufoForm('foo')
         model.addTufoProp('foo','bar',ptype='bool', defval=0)
@@ -116,6 +125,7 @@ class DataModelTest(SynTest):
 
     def test_datamodel_hash(self):
         model = s_datamodel.DataModel()
+        model.addDefaultTypes()
 
         model.addTufoForm('foo')
 
@@ -172,8 +182,8 @@ class DataModelTest(SynTest):
 
 
     def test_datamodel_inet(self):
-
         model = s_datamodel.DataModel()
+        model.addDefaultTypes()
 
         model.addTufoForm('foo')
         model.addTufoProp('foo','addr', ptype='inet:ipv4')
@@ -195,8 +205,8 @@ class DataModelTest(SynTest):
         self.assertRaises( BadTypeValu, model.getPropParse, 'foo:port', '999999' )
 
     def test_datamodel_time(self):
-
         model = s_datamodel.DataModel()
+        model.addDefaultTypes()
 
         model.addTufoForm('foo')
         model.addTufoProp('foo','meow', ptype='time:epoch')
@@ -208,6 +218,8 @@ class DataModelTest(SynTest):
 
     def test_datamodel_badprop(self):
         model = s_datamodel.DataModel()
+        model.addDefaultTypes()
+
         self.assertRaises( s_datamodel.BadPropName, model.addTufoForm, 'foo.bar' )
 
         model.addTufoForm('foo:bar')

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -180,7 +180,6 @@ class DataModelTest(SynTest):
         self.assertEqual( ret.get('size'), 10 )
         self.assertEqual( ret.get('flag'), 'asdf')
 
-
     def test_datamodel_inet(self):
         model = s_datamodel.DataModel()
         model.addDefaultTypes()

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -9,8 +9,6 @@ class DataModelTest(SynTest):
 
     def test_datamodel_types(self):
         model = s_datamodel.DataModel()
-        model.addDefaultTypes()
-        model.bootstrapForms()
 
         model.addTufoForm('foo')
         model.addTufoProp('foo', 'bar', ptype='int')
@@ -35,8 +33,6 @@ class DataModelTest(SynTest):
 
     def test_datamodel_glob(self):
         model = s_datamodel.DataModel()
-        model.addDefaultTypes()
-        model.bootstrapForms()
 
         model.addTufoForm('foo')
         model.addPropGlob('foo:bar:*',ptype='str:lwr')
@@ -44,16 +40,12 @@ class DataModelTest(SynTest):
 
     def test_datamodel_fail_notype(self):
         model = s_datamodel.DataModel()
-        model.addDefaultTypes()
-        model.bootstrapForms()
 
         model.addTufoForm('foo')
         self.assertRaises( s_datamodel.NoSuchType, model.addTufoProp, 'foo', 'bar', ptype='hehe' )
 
     def test_datamodel_fail_noprop(self):
         model = s_datamodel.DataModel()
-        model.addDefaultTypes()
-        model.bootstrapForms()
 
         self.assertRaises( NoSuchForm, model.addTufoProp, 'foo', 'bar' )
 
@@ -94,8 +86,6 @@ class DataModelTest(SynTest):
 
     def test_datamodel_subs(self):
         model = s_datamodel.DataModel()
-        model.addDefaultTypes()
-        model.bootstrapForms()
 
         model.addTufoForm('foo')
         model.addTufoProp('foo','bar',ptype='int')
@@ -112,8 +102,6 @@ class DataModelTest(SynTest):
 
     def test_datamodel_bool(self):
         model = s_datamodel.DataModel()
-        model.addDefaultTypes()
-        model.bootstrapForms()
 
         model.addTufoForm('foo')
         model.addTufoProp('foo','bar',ptype='bool', defval=0)
@@ -131,8 +119,6 @@ class DataModelTest(SynTest):
 
     def test_datamodel_hash(self):
         model = s_datamodel.DataModel()
-        model.addDefaultTypes()
-        model.bootstrapForms()
 
         model.addTufoForm('foo')
 
@@ -189,8 +175,6 @@ class DataModelTest(SynTest):
 
     def test_datamodel_inet(self):
         model = s_datamodel.DataModel()
-        model.addDefaultTypes()
-        model.bootstrapForms()
 
         model.addTufoForm('foo')
         model.addTufoProp('foo','addr', ptype='inet:ipv4')
@@ -213,8 +197,6 @@ class DataModelTest(SynTest):
 
     def test_datamodel_time(self):
         model = s_datamodel.DataModel()
-        model.addDefaultTypes()
-        model.bootstrapForms()
 
         model.addTufoForm('foo')
         model.addTufoProp('foo','meow', ptype='time:epoch')
@@ -226,8 +208,6 @@ class DataModelTest(SynTest):
 
     def test_datamodel_badprop(self):
         model = s_datamodel.DataModel()
-        model.addDefaultTypes()
-        model.bootstrapForms()
 
         self.assertRaises( s_datamodel.BadPropName, model.addTufoForm, 'foo.bar' )
 
@@ -236,8 +216,6 @@ class DataModelTest(SynTest):
 
     def test_datatype_syn_prop(self):
         model = s_datamodel.DataModel()
-        model.addDefaultTypes()
-        model.bootstrapForms()
 
         self.assertRaises(BadTypeValu, model.getTypeNorm, 'syn:prop', 'asdf qwer' )
         self.assertRaises(BadTypeValu, model.getTypeNorm, 'syn:prop', 'foo::bar' )
@@ -250,8 +228,6 @@ class DataModelTest(SynTest):
 
     def test_datatype_syn_tag(self):
         model = s_datamodel.DataModel()
-        model.addDefaultTypes()
-        model.bootstrapForms()
 
         self.assertRaises(BadTypeValu, model.getTypeNorm, 'syn:tag', 'asdf qwer' )
         self.assertRaises(BadTypeValu, model.getTypeNorm, 'syn:tag', 'foo..bar' )

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -10,6 +10,7 @@ class DataModelTest(SynTest):
     def test_datamodel_types(self):
         model = s_datamodel.DataModel()
         model.addDefaultTypes()
+        model.bootstrapForms()
 
         model.addTufoForm('foo')
         model.addTufoProp('foo', 'bar', ptype='int')
@@ -35,6 +36,7 @@ class DataModelTest(SynTest):
     def test_datamodel_glob(self):
         model = s_datamodel.DataModel()
         model.addDefaultTypes()
+        model.bootstrapForms()
 
         model.addTufoForm('foo')
         model.addPropGlob('foo:bar:*',ptype='str:lwr')
@@ -43,6 +45,7 @@ class DataModelTest(SynTest):
     def test_datamodel_fail_notype(self):
         model = s_datamodel.DataModel()
         model.addDefaultTypes()
+        model.bootstrapForms()
 
         model.addTufoForm('foo')
         self.assertRaises( s_datamodel.NoSuchType, model.addTufoProp, 'foo', 'bar', ptype='hehe' )
@@ -50,6 +53,7 @@ class DataModelTest(SynTest):
     def test_datamodel_fail_noprop(self):
         model = s_datamodel.DataModel()
         model.addDefaultTypes()
+        model.bootstrapForms()
 
         self.assertRaises( NoSuchForm, model.addTufoProp, 'foo', 'bar' )
 
@@ -91,6 +95,7 @@ class DataModelTest(SynTest):
     def test_datamodel_subs(self):
         model = s_datamodel.DataModel()
         model.addDefaultTypes()
+        model.bootstrapForms()
 
         model.addTufoForm('foo')
         model.addTufoProp('foo','bar',ptype='int')
@@ -108,6 +113,7 @@ class DataModelTest(SynTest):
     def test_datamodel_bool(self):
         model = s_datamodel.DataModel()
         model.addDefaultTypes()
+        model.bootstrapForms()
 
         model.addTufoForm('foo')
         model.addTufoProp('foo','bar',ptype='bool', defval=0)
@@ -126,6 +132,7 @@ class DataModelTest(SynTest):
     def test_datamodel_hash(self):
         model = s_datamodel.DataModel()
         model.addDefaultTypes()
+        model.bootstrapForms()
 
         model.addTufoForm('foo')
 
@@ -183,6 +190,7 @@ class DataModelTest(SynTest):
     def test_datamodel_inet(self):
         model = s_datamodel.DataModel()
         model.addDefaultTypes()
+        model.bootstrapForms()
 
         model.addTufoForm('foo')
         model.addTufoProp('foo','addr', ptype='inet:ipv4')
@@ -206,6 +214,7 @@ class DataModelTest(SynTest):
     def test_datamodel_time(self):
         model = s_datamodel.DataModel()
         model.addDefaultTypes()
+        model.bootstrapForms()
 
         model.addTufoForm('foo')
         model.addTufoProp('foo','meow', ptype='time:epoch')
@@ -218,6 +227,7 @@ class DataModelTest(SynTest):
     def test_datamodel_badprop(self):
         model = s_datamodel.DataModel()
         model.addDefaultTypes()
+        model.bootstrapForms()
 
         self.assertRaises( s_datamodel.BadPropName, model.addTufoForm, 'foo.bar' )
 

--- a/synapse/tests/test_datamodel.py
+++ b/synapse/tests/test_datamodel.py
@@ -233,3 +233,32 @@ class DataModelTest(SynTest):
 
         model.addTufoForm('foo:bar')
         self.assertRaises( s_datamodel.BadPropName, model.addTufoProp, 'foo:bar', 'b*z' )
+
+    def test_datatype_syn_prop(self):
+        model = s_datamodel.DataModel()
+        model.addDefaultTypes()
+        model.bootstrapForms()
+
+        self.assertRaises(BadTypeValu, model.getTypeNorm, 'syn:prop', 'asdf qwer' )
+        self.assertRaises(BadTypeValu, model.getTypeNorm, 'syn:prop', 'foo::bar' )
+
+        self.eq( model.getTypeFrob('syn:prop','BAR'), 'bar' )
+        self.eq( model.getTypeNorm('syn:prop','BAR'), 'bar' )
+        self.eq( model.getTypeParse('syn:prop','BAR'), 'bar' )
+        self.eq( model.getTypeNorm('syn:prop','foo:BAR'), 'foo:bar' )
+        self.eq( model.getTypeParse('syn:prop','foo:BAR'), 'foo:bar' )
+
+    def test_datatype_syn_tag(self):
+        model = s_datamodel.DataModel()
+        model.addDefaultTypes()
+        model.bootstrapForms()
+
+        self.assertRaises(BadTypeValu, model.getTypeNorm, 'syn:tag', 'asdf qwer' )
+        self.assertRaises(BadTypeValu, model.getTypeNorm, 'syn:tag', 'foo..bar' )
+
+        self.eq( model.getTypeNorm('syn:tag','BAR'), 'bar' )
+        self.eq( model.getTypeParse('syn:tag','BAR'), 'bar' )
+        self.eq( model.getTypeNorm('syn:tag','foo.BAR'), 'foo.bar' )
+        self.eq( model.getTypeParse('syn:tag','foo.BAR'), 'foo.bar' )
+
+

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -8,7 +8,6 @@ class DataTypesTest(SynTest):
     def test_datatype_basics(self):
 
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
         self.assertTrue( isinstance(tlib.getDataType('inet:url'), s_types.DataType) )
 
         self.assertIsNone( tlib.getDataType('newp') )
@@ -16,7 +15,6 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_url(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         self.assertRaises( BadTypeValu, tlib.getTypeNorm, 'inet:url', 'newp' )
         self.eq( tlib.getTypeNorm('inet:url','http://WoOt.com/HeHe'), 'http://woot.com/HeHe' )
@@ -36,7 +34,6 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_ipv4(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         self.eq( tlib.getTypeNorm('inet:ipv4',0x01020304), 0x01020304 )
 
@@ -49,7 +46,6 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_tcp4(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         self.eq( tlib.getTypeNorm('inet:tcp4',0x010203040002), 0x010203040002 )
 
@@ -63,7 +59,6 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_udp4(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         self.eq( tlib.getTypeNorm('inet:udp4',0x010203040002), 0x010203040002 )
 
@@ -77,7 +72,6 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_port(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeParse, 'inet:port', '70000' )
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'inet:port', 0xffffffff )
@@ -86,7 +80,6 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_mac(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeParse, 'inet:mac', 'newp' )
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'inet:mac', 'newp' )
@@ -98,7 +91,6 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_email(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeParse, 'inet:email', 'newp' )
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'inet:email', 'newp' )
@@ -111,7 +103,6 @@ class DataTypesTest(SynTest):
 
     def test_datatype_guid(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeParse, 'guid', 'newp' )
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'guid', 'newp' )
@@ -124,7 +115,6 @@ class DataTypesTest(SynTest):
 
     def test_datatype_guid_sub(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         tlib.addSubType('woot','guid')
 
@@ -138,7 +128,6 @@ class DataTypesTest(SynTest):
 
     def test_datatype_hash_md5(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeParse, 'hash:md5', 'newp' )
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'hash:md5', 'newp' )
@@ -150,7 +139,6 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_ipv6(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeParse, 'inet:ipv6', 'newp' )
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'inet:srv6', 'newp' )
@@ -175,7 +163,6 @@ class DataTypesTest(SynTest):
 
     def test_datatype_str(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'str', 10 )
 
@@ -185,7 +172,6 @@ class DataTypesTest(SynTest):
 
     def test_datatype_str_enums(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         tlib.addSubType('woot','str',enums=('hehe','haha','hoho'), lower=True)
 
@@ -198,13 +184,11 @@ class DataTypesTest(SynTest):
 
     def test_datatype_dup(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         self.assertRaises(DupTypeName, tlib.addSubType, 'inet:port', 'int' )
 
     def test_datatype_bool(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeParse, 'bool', 'bogus' )
 
@@ -235,7 +219,6 @@ class DataTypesTest(SynTest):
 
     def test_type_comp(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         fields = ( ('fqdn','inet:fqdn'), ('ipv4','inet:ipv4'), ('time','time:epoch') )
         tlib.addSubType('inet:dns:a','comp',fields=fields)
@@ -281,7 +264,6 @@ class DataTypesTest(SynTest):
 
     def test_type_comp_chop(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         fields = ( ('fqdn','inet:fqdn'), ('email','inet:email'))
         tlib.addSubType('fake:newp','comp',fields=fields)
@@ -290,7 +272,6 @@ class DataTypesTest(SynTest):
 
     def test_datatype_int_minmax(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         tlib.addSubType('woot:min','int',ismin=True)
         tlib.addSubType('woot:max','int',ismax=True)
@@ -303,7 +284,6 @@ class DataTypesTest(SynTest):
 
     def test_datatype_fqdn(self):
         tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
 
         self.eq( tlib.getTypeNorm('inet:fqdn','WOOT.COM'), 'woot.com')
         self.eq( tlib.getTypeNorm('inet:fqdn','WO-OT.COM'), 'wo-ot.com')

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -8,6 +8,7 @@ class DataTypesTest(SynTest):
     def test_datatype_basics(self):
 
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
         self.assertTrue( isinstance(tlib.getDataType('inet:url'), s_types.DataType) )
 
         self.assertIsNone( tlib.getDataType('newp') )
@@ -15,6 +16,7 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_url(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         self.assertRaises( BadTypeValu, tlib.getTypeNorm, 'inet:url', 'newp' )
         self.eq( tlib.getTypeNorm('inet:url','http://WoOt.com/HeHe'), 'http://woot.com/HeHe' )
@@ -34,6 +36,7 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_ipv4(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         self.eq( tlib.getTypeNorm('inet:ipv4',0x01020304), 0x01020304 )
 
@@ -46,6 +49,7 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_tcp4(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         self.eq( tlib.getTypeNorm('inet:tcp4',0x010203040002), 0x010203040002 )
 
@@ -59,6 +63,7 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_udp4(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         self.eq( tlib.getTypeNorm('inet:udp4',0x010203040002), 0x010203040002 )
 
@@ -72,6 +77,7 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_port(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeParse, 'inet:port', '70000' )
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'inet:port', 0xffffffff )
@@ -80,6 +86,7 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_mac(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeParse, 'inet:mac', 'newp' )
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'inet:mac', 'newp' )
@@ -91,6 +98,7 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_email(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeParse, 'inet:email', 'newp' )
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'inet:email', 'newp' )
@@ -103,6 +111,7 @@ class DataTypesTest(SynTest):
 
     def test_datatype_guid(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeParse, 'guid', 'newp' )
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'guid', 'newp' )
@@ -115,6 +124,7 @@ class DataTypesTest(SynTest):
 
     def test_datatype_guid_sub(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         tlib.addSubType('woot','guid')
 
@@ -128,6 +138,7 @@ class DataTypesTest(SynTest):
 
     def test_datatype_hash_md5(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeParse, 'hash:md5', 'newp' )
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'hash:md5', 'newp' )
@@ -139,6 +150,7 @@ class DataTypesTest(SynTest):
 
     def test_datatype_inet_ipv6(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeParse, 'inet:ipv6', 'newp' )
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'inet:srv6', 'newp' )
@@ -163,6 +175,7 @@ class DataTypesTest(SynTest):
 
     def test_datatype_str(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'str', 10 )
 
@@ -172,6 +185,7 @@ class DataTypesTest(SynTest):
 
     def test_datatype_str_enums(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         tlib.addSubType('woot','str',enums=('hehe','haha','hoho'), lower=True)
 
@@ -184,11 +198,14 @@ class DataTypesTest(SynTest):
 
     def test_datatype_dup(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
+
         self.assertRaises(DupTypeName, tlib.addSubType, 'inet:port', 'int' )
 
     def test_datatype_syn_tag(self):
-
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
+
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'syn:tag', 'asdf qwer' )
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'syn:tag', 'foo..bar' )
 
@@ -199,6 +216,8 @@ class DataTypesTest(SynTest):
 
     def test_datatype_syn_prop(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
+
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'syn:prop', 'asdf qwer' )
         self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'syn:prop', 'foo::bar' )
 
@@ -210,6 +229,7 @@ class DataTypesTest(SynTest):
 
     def test_datatype_bool(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         self.assertRaises(BadTypeValu, tlib.getTypeParse, 'bool', 'bogus' )
 
@@ -240,6 +260,7 @@ class DataTypesTest(SynTest):
 
     def test_type_comp(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         fields = ( ('fqdn','inet:fqdn'), ('ipv4','inet:ipv4'), ('time','time:epoch') )
         tlib.addSubType('inet:dns:a','comp',fields=fields)
@@ -285,6 +306,7 @@ class DataTypesTest(SynTest):
 
     def test_type_comp_chop(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         fields = ( ('fqdn','inet:fqdn'), ('email','inet:email'))
         tlib.addSubType('fake:newp','comp',fields=fields)
@@ -293,6 +315,7 @@ class DataTypesTest(SynTest):
 
     def test_datatype_int_minmax(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
 
         tlib.addSubType('woot:min','int',ismin=True)
         tlib.addSubType('woot:max','int',ismax=True)
@@ -305,6 +328,8 @@ class DataTypesTest(SynTest):
 
     def test_datatype_fqdn(self):
         tlib = s_types.TypeLib()
+        tlib.addDefaultTypes()
+
         self.eq( tlib.getTypeNorm('inet:fqdn','WOOT.COM'), 'woot.com')
         self.eq( tlib.getTypeNorm('inet:fqdn','WO-OT.COM'), 'wo-ot.com')
         self.eq( tlib.getTypeFrob('inet:fqdn','WOOT.COM'), 'woot.com')

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -202,31 +202,6 @@ class DataTypesTest(SynTest):
 
         self.assertRaises(DupTypeName, tlib.addSubType, 'inet:port', 'int' )
 
-    def test_datatype_syn_tag(self):
-        tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
-
-        self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'syn:tag', 'asdf qwer' )
-        self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'syn:tag', 'foo..bar' )
-
-        self.eq( tlib.getTypeNorm('syn:tag','BAR'), 'bar' )
-        self.eq( tlib.getTypeParse('syn:tag','BAR'), 'bar' )
-        self.eq( tlib.getTypeNorm('syn:tag','foo.BAR'), 'foo.bar' )
-        self.eq( tlib.getTypeParse('syn:tag','foo.BAR'), 'foo.bar' )
-
-    def test_datatype_syn_prop(self):
-        tlib = s_types.TypeLib()
-        tlib.addDefaultTypes()
-
-        self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'syn:prop', 'asdf qwer' )
-        self.assertRaises(BadTypeValu, tlib.getTypeNorm, 'syn:prop', 'foo::bar' )
-
-        self.eq( tlib.getTypeFrob('syn:prop','BAR'), 'bar' )
-        self.eq( tlib.getTypeNorm('syn:prop','BAR'), 'bar' )
-        self.eq( tlib.getTypeParse('syn:prop','BAR'), 'bar' )
-        self.eq( tlib.getTypeNorm('syn:prop','foo:BAR'), 'foo:bar' )
-        self.eq( tlib.getTypeParse('syn:prop','foo:BAR'), 'foo:bar' )
-
     def test_datatype_bool(self):
         tlib = s_types.TypeLib()
         tlib.addDefaultTypes()


### PR DESCRIPTION
when cortex clients call `addType()`, `addTufoForm()`, and friends, add tufos to the cortex that describe the types and data models.

this is a one-way backing only. for example, types are added as `syn:type` tufos, which can be inspected via cortex/swarm. however, changes made to `syn:type` tufos via cortex/swarm *do not* affect the installed types. likewise, upon reload of the cortex, the types still must be re-installed (since there's a code component that must be present to do parsing, frobbing, etc). the cortex persistence is just metadata.

this lays the groundwork for a cortex loader that can inspect the cortex and automatically import/configure/run typelibs and datamodels when a cortex is reloaded.

i've made a bunch of changes to which i expect discussion/suggestion/feedback. i figured its easier to discuss real, existing code than concepts. i am happy to discuss and rework anything here.