### PR TITLE
add cortex model registration and loader

### DIFF
--- a/synapse/common.py
+++ b/synapse/common.py
@@ -4,14 +4,11 @@ import os
 import sys
 import json
 import time
-import shutil
 import msgpack
 import logging
-import tempfile
 import functools
 import threading
 import traceback
-import contextlib
 
 from binascii import hexlify
 
@@ -184,18 +181,4 @@ def worker(meth, *args, **kwargs):
     thr.setDaemon(True)
     thr.start()
     return thr
-
-@contextlib.contextmanager
-def tempdir():
-    d = None
-    try:
-        d = tempfile.mkdtemp()
-        yield d
-    finally:
-        try:
-            shutil.rmtree(d)
-        except:
-            # we did the best we could...
-            logger.warn('failed to remove directory: %s', d)
-
 

--- a/synapse/common.py
+++ b/synapse/common.py
@@ -4,15 +4,23 @@ import os
 import sys
 import json
 import time
+import shutil
 import msgpack
+import logging
+import tempfile
 import functools
 import threading
 import traceback
+import contextlib
 
 from binascii import hexlify
 
 from synapse.exc import *
 from synapse.compat import enbase64, debase64
+
+
+logger = logging.getLogger(__name__)
+
 
 def now():
     return int(time.time())
@@ -176,3 +184,18 @@ def worker(meth, *args, **kwargs):
     thr.setDaemon(True)
     thr.start()
     return thr
+
+@contextlib.contextmanager
+def tempdir():
+    d = None
+    try:
+        d = tempfile.mkdtemp()
+        yield d
+    finally:
+        try:
+            shutil.rmtree(d)
+        except:
+            # we did the best we could...
+            logger.warn('failed to remove directory: %s', d)
+
+

--- a/synapse/cortex.py
+++ b/synapse/cortex.py
@@ -20,6 +20,7 @@ insertion, and provide for atomic deconfliction if needed.
 import synapse.link as s_link
 import synapse.async as s_async
 import synapse.lib.sched as s_sched
+import synapse.datamodel as s_datamodel
 
 import synapse.cores.ram
 import synapse.cores.sqlite
@@ -45,6 +46,11 @@ corctors = {
     'sqlite':synapse.cores.sqlite.Cortex,
     'postgres':synapse.cores.postgres.Cortex,
 }
+
+
+def shouldLoadModels(link):
+    return s_datamodel.getTypeParse('bool', link[1].get('nomodels', '0')) == 0
+
 
 def openurl(url, **opts):
     '''
@@ -89,6 +95,9 @@ def openlink(link):
     if savefile != None:
         savefd = genfile(savefile)
         core.setSaveFd(savefd,fini=True)
+
+    if shouldLoadModels(link):
+        core.loadModels()
 
     return core
 

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1183,7 +1183,7 @@ class CortexTest(SynTest):
             self.assertRaises( BadPropValu, core.formTufoByProp, 'foo:bar', True )
 
     def test_cortex_loader(self):
-        with s_common.tempdir() as path:
+        with self.getTestDir() as path:
             with s_cortex.openurl('sqlite:////' + path + '/a.db') as core:
                 core.registerModel(THIS_MODULE)
 
@@ -1191,7 +1191,7 @@ class CortexTest(SynTest):
                 self.assertTrue('test:foo' in core.forms)
 
     def test_cortex_loader_noload(self):
-        with s_common.tempdir() as path:
+        with self.getTestDir() as path:
             with s_cortex.openurl('sqlite:////' + path + '/a.db') as core:
                 core.registerModel(THIS_MODULE)
 
@@ -1199,7 +1199,7 @@ class CortexTest(SynTest):
                 self.assertTrue('test:foo' not in core.forms)
 
     def test_cortex_loader_explicit_load(self):
-        with s_common.tempdir() as path:
+        with self.getTestDir() as path:
             with s_cortex.openurl('sqlite:////' + path + '/a.db') as core:
                 core.registerModel(THIS_MODULE)
 
@@ -1209,7 +1209,7 @@ class CortexTest(SynTest):
                 self.assertTrue('test:foo' in core.forms)
 
     def test_cortex_loader_upgrade_ok(self):
-        with s_common.tempdir() as path:
+        with self.getTestDir() as path:
             with s_cortex.openurl('sqlite:////' + path + '/a.db') as core:
                 core.registerModel(THIS_MODULE)
 
@@ -1227,7 +1227,7 @@ class CortexTest(SynTest):
         demonstrate the IncompatibleModelVersion exception thats raise when the importable
          Cortex model provider cannot offer a new-enough version.
         '''
-        with s_common.tempdir() as path:
+        with self.getTestDir() as path:
             with s_cortex.openurl('sqlite:////' + path + '/a.db') as core:
                 # register version two
                 global VERSION

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -24,9 +24,6 @@ VERSION = 1
 THIS_MODULE = sys.modules[__name__]
 
 def getInfo():
-    '''
-    extra metadata, like `doc`.
-    '''
     return {
         'namespace': 'test',
         'version': VERSION,


### PR DESCRIPTION
this PR adds methods to a cortex that register models to be automatically re-loaded when the cortex is restarted. this means that in a user application, a single initialization routine can configure a cortex with appropriate types and forms, and these types and forms will "magically" work for any other cortex clients. no need to call `addForm` on every boot.

the PR introduces the concept of a cortex model provider; this is an importable Python module with some well-known top-level functions:

  - `getInfo()`: returns a dict with the required keys:
    - `namespace` (`str`): unique prefix for types and forms added by this module.
    - `version` (`int`): the revision number of this model. this *must* increment with every change.
  - `addTypes` (`synapse.cores.common.Cortex`): add any provided types to the given cortex.
  - `addForms` (`synapse.cores.common.Cortex`): add any provided forms to the given cortex.
  - `upgradeModel` (`synapse.cores.common.Cortex`): when invoked, the cortex is using an out-of-date model version, and requests to be updated to the latest version. implementor must update any cortex-persisted types or forms (more relevant once #94 is merged).

initialization routines install a model provider into a cortex using `core.registerModel(the.model.provider.module)`. when a previously configured cortex is restarted, it inspects itself, imports the installed model providers, and invokes their exposed routines. 

the cortex can be started without invoking the model providers by using the query parameter `nomodels=1` to the cortex url.