### PR TITLE
Change postgres strval index to use md5(strval) to avoid the postgres…

### DIFF
--- a/synapse/cores/sqlite.py
+++ b/synapse/cores/sqlite.py
@@ -12,138 +12,6 @@ int_t = s_compat.typeof(0)
 str_t = s_compat.typeof('visi')
 none_t = s_compat.typeof(None)
 
-istable = '''
-    SELECT
-        name
-    FROM
-        sqlite_master
-    WHERE
-        type='table'
-    AND
-        name=?
-'''
-
-inittable = '''
-CREATE TABLE %s (
-    id VARCHAR,
-    prop VARCHAR,
-    strval TEXT,
-    intval BIGINT,
-    stamp BIGINT
-);
-'''
-
-init_id_idx = 'CREATE INDEX %s_id_idx ON %s (id,prop)'
-init_strval_idx = 'CREATE INDEX %s_prop_time_idx ON %s (prop,stamp)'
-init_strval_idx = 'CREATE INDEX %s_strval_idx ON %s (prop,strval,stamp)'
-init_intval_idx = 'CREATE INDEX %s_intval_idx ON %s (prop,intval,stamp)'
-
-addrows = 'INSERT INTO %s (id,prop,strval,intval,stamp) VALUES (?,?,?,?,?)'
-getrows_by_id = 'SELECT * FROM %s WHERE id=?'
-getrows_by_range = 'SELECT * FROM %s WHERE prop=? and intval >= ? AND intval < ? LIMIT ?'
-getrows_by_le = 'SELECT * FROM %s WHERE prop=? and intval <= ? LIMIT ?'
-getrows_by_ge = 'SELECT * FROM %s WHERE prop=? and intval >= ? LIMIT ?'
-getrows_by_id_prop = 'SELECT * FROM %s WHERE id=? AND prop=?'
-
-################################################################################
-getrows_by_prop = 'SELECT * FROM %s WHERE prop=? LIMIT ?'
-getrows_by_prop_int = 'SELECT * FROM %s WHERE prop=? AND intval=? LIMIT ?'
-getrows_by_prop_str = 'SELECT * FROM %s WHERE prop=? AND strval=? LIMIT ?'
-
-getrows_by_prop_wmin = 'SELECT * FROM %s WHERE prop=? AND stamp >=? LIMIT ?'
-getrows_by_prop_int_wmin = 'SELECT * FROM %s WHERE prop=? AND intval=? AND stamp >=? LIMIT ?'
-getrows_by_prop_str_wmin = 'SELECT * FROM %s WHERE prop=? AND strval=? AND stamp >=? LIMIT ?'
-
-getrows_by_prop_wmax = 'SELECT * FROM %s WHERE prop=? AND stamp<? LIMIT ?'
-getrows_by_prop_int_wmax = 'SELECT * FROM %s WHERE prop=? AND intval=? AND stamp<? LIMIT ?'
-getrows_by_prop_str_wmax = 'SELECT * FROM %s WHERE prop=? AND strval=? AND stamp<? LIMIT ?'
-
-getrows_by_prop_wminmax = 'SELECT * FROM %s WHERE prop=? AND stamp>=? AND stamp<? LIMIT ?'
-getrows_by_prop_int_wminmax = 'SELECT * FROM %s WHERE prop=? AND intval=? AND stamp>=? AND stamp<? LIMIT ?'
-getrows_by_prop_str_wminmax = 'SELECT * FROM %s WHERE prop=? AND strval=? AND stamp>=? AND stamp<? LIMIT ?'
-################################################################################
-getsize_by_prop = 'SELECT COUNT(*) FROM %s WHERE prop=? LIMIT ?'
-getsize_by_prop_int = 'SELECT COUNT(*) FROM %s WHERE prop=? AND intval=? LIMIT ?'
-getsize_by_prop_str = 'SELECT COUNT(*) FROM %s WHERE prop=? AND strval=? LIMIT ?'
-
-getsize_by_prop_wmin = 'SELECT COUNT(*) FROM %s WHERE prop=? AND stamp>=? LIMIT ?'
-getsize_by_prop_int_wmin = 'SELECT COUNT(*) FROM %s WHERE prop=? AND intval=? AND stamp>=? LIMIT ?'
-getsize_by_prop_str_wmin = 'SELECT COUNT(*) FROM %s WHERE prop=? AND strval=? AND stamp>=? LIMIT ?'
-
-getsize_by_prop_wmax = 'SELECT COUNT(*) FROM %s WHERE prop=? AND stamp<? LIMIT ?'
-getsize_by_prop_int_wmax = 'SELECT COUNT(*) FROM %s WHERE prop=? AND intval=? AND stamp<? LIMIT ?'
-getsize_by_prop_str_wmax = 'SELECT COUNT(*) FROM %s WHERE prop=? AND strval=? AND stamp<? LIMIT ?'
-
-getsize_by_prop_wminmax = 'SELECT COUNT(*) FROM %s WHERE prop=? AND stamp>=? AND stamp<? LIMIT ?'
-getsize_by_prop_int_wminmax = 'SELECT COUNT(*) FROM %s WHERE prop=? AND intval=? AND stamp>=? AND stamp<? LIMIT ?'
-getsize_by_prop_str_wminmax = 'SELECT COUNT(*) FROM %s WHERE prop=? AND strval=? AND stamp>=? AND stamp<? LIMIT ?'
-################################################################################
-
-getsize_by_range = 'SELECT COUNT(*) FROM %s WHERE prop=? and intval >= ? AND intval < ? LIMIT ?'
-getsize_by_le = 'SELECT COUNT(*) FROM %s WHERE prop=? and intval <= ? LIMIT ?'
-getsize_by_ge = 'SELECT COUNT(*) FROM %s WHERE prop=? and intval >= ? LIMIT ?'
-
-delrows_by_id = 'DELETE FROM %s WHERE id=?'
-delrows_by_id_prop = 'DELETE FROM %s WHERE id=? AND prop=?'
-
-################################################################################
-delrows_by_prop = 'DELETE FROM %s WHERE prop=?'
-delrows_by_prop_int = 'DELETE FROM %s WHERE prop=? AND intval=?'
-delrows_by_prop_str = 'DELETE FROM %s WHERE prop=? AND strval=?'
-
-delrows_by_prop_wmin = 'DELETE FROM %s WHERE prop=? AND stamp>=?'
-delrows_by_prop_int_wmin = 'DELETE FROM %s WHERE prop=? AND intval=? AND stamp>=?'
-delrows_by_prop_str_wmin = 'DELETE FROM %s WHERE prop=? AND strval=? AND stamp>=?'
-
-delrows_by_prop_wmax = 'DELETE FROM %s WHERE prop=? AND stamp<?'
-delrows_by_prop_int_wmax = 'DELETE FROM %s WHERE prop=? AND intval=? AND stamp<?'
-delrows_by_prop_str_wmax = 'DELETE FROM %s WHERE prop=? AND strval=? AND stamp<?'
-
-delrows_by_prop_wminmax = 'DELETE FROM %s WHERE prop=? AND stamp>=? AND stamp<?'
-delrows_by_prop_int_wminmax = 'DELETE FROM %s WHERE prop=? AND intval=? AND stamp>=? AND stamp<?'
-delrows_by_prop_str_wminmax = 'DELETE FROM %s WHERE prop=? AND strval=? AND stamp>=? AND stamp<?'
-
-################################################################################
-getjoin_by_prop = 'SELECT * from %s WHERE id IN (SELECT id FROM %s WHERE prop=? LIMIT ?)'
-getjoin_by_prop_int = 'SELECT * from %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND intval=? LIMIT ?)'
-getjoin_by_prop_str = 'SELECT * from %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND strval=? LIMIT ?)'
-
-getjoin_by_prop_wmin = 'SELECT * from %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND stamp>=? LIMIT ?)'
-getjoin_by_prop_int_wmin = 'SELECT * from %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND intval=? AND stamp>=? LIMIT ?)'
-getjoin_by_prop_str_wmin = 'SELECT * from %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND strval=? AND stamp>=? LIMIT ?)'
-
-getjoin_by_prop_wmax = 'SELECT * from %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND stamp<? LIMIT ?)'
-getjoin_by_prop_int_wmax = 'SELECT * from %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND intval=? AND stamp<? LIMIT ?)'
-getjoin_by_prop_str_wmax = 'SELECT * from %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND strval=? AND stamp<? LIMIT ?)'
-
-getjoin_by_prop_wminmax = 'SELECT * from %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND stamp>=? AND stamp<? LIMIT ?)'
-getjoin_by_prop_int_wminmax = 'SELECT * from %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND intval=? AND stamp>=? AND stamp<? LIMIT ?)'
-getjoin_by_prop_str_wminmax = 'SELECT * from %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND strval=? AND stamp>=? AND stamp<? LIMIT ?)'
-
-getjoin_by_range_int = 'SELECT * FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=? and ? <= intval AND intval < ? LIMIT ?)'
-getjoin_by_range_str = 'SELECT * FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=? and ? <= strval AND strval < ? LIMIT ?)'
-
-################################################################################
-deljoin_by_prop = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=?)'
-deljoin_by_prop_int = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND intval=?)'
-deljoin_by_prop_str = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND strval=?)'
-
-deljoin_by_prop_wmin = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND stamp>=? )'
-deljoin_by_prop_int_wmin = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND intval=? AND stamp>=? )'
-deljoin_by_prop_str_wmin = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND strval=? AND stamp>=? )'
-
-deljoin_by_prop_wmax = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND stamp<? )'
-deljoin_by_prop_int_wmax = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND intval=? AND stamp<? )'
-deljoin_by_prop_str_wmax = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND strval=? AND stamp<? )'
-
-deljoin_by_prop_wminmax = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND stamp>=? AND stamp <?)'
-deljoin_by_prop_int_wminmax = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND intval=?)'
-deljoin_by_prop_str_wminmax = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=? AND strval=?)'
-################################################################################
-
-uprows_by_id_prop_str = 'UPDATE %s SET strval=? WHERE id=? and prop=?'
-uprows_by_id_prop_int = 'UPDATE %s SET intval=? WHERE id=? and prop=?'
-
 class WithCursor:
 
     def __init__(self, pool, db, cursor):
@@ -200,8 +68,141 @@ class DbPool:
 
 class Cortex(common.Cortex):
 
-    dbvar = '?'
+    dbvar_open = ':'
+    dbvar_close = ''
     dblim = -1
+
+    istable = '''
+        SELECT
+            name
+        FROM
+            sqlite_master
+        WHERE
+            type='table'
+        AND
+            name=?
+    '''
+
+    inittable = '''
+    CREATE TABLE %s (
+        id VARCHAR,
+        prop VARCHAR,
+        strval TEXT,
+        intval BIGINT,
+        stamp BIGINT
+    );
+    '''
+
+    init_id_idx = 'CREATE INDEX %s_id_idx ON %s (id,prop)'
+    init_prop_idx = 'CREATE INDEX %s_prop_idx ON %s (prop,stamp)'
+    init_strval_idx = 'CREATE INDEX %s_strval_idx ON %s (prop,strval,stamp)'
+    init_intval_idx = 'CREATE INDEX %s_intval_idx ON %s (prop,intval,stamp)'
+
+    addrows = 'INSERT INTO %s (id,prop,strval,intval,stamp) VALUES (?:iden:?,?:prop:?,?:strval:?,?:intval:?,?:stamp:?)'
+    getrows_by_id = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE id=?:iden:?'
+    getrows_by_range = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE prop=?:prop:? and intval>=?:min:? AND intval<?:max:? LIMIT ?:limit:?'
+    getrows_by_le = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE prop=?:prop:? and intval<=?:valu:? LIMIT ?:limit:?'
+    getrows_by_ge = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE prop=?:prop:? and intval>=?:valu:? LIMIT ?:limit:?'
+    getrows_by_id_prop = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE id=?:iden:? AND prop=?:prop:?'
+
+    ################################################################################
+    getrows_by_prop = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE prop=?:prop:? LIMIT ?:limit:?'
+    getrows_by_prop_int = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE prop=?:prop:? AND intval=?:valu:? LIMIT ?:limit:?'
+    getrows_by_prop_str = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE prop=?:prop:? AND strval=?:valu:? LIMIT ?:limit:?'
+
+    getrows_by_prop_wmin = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE prop=?:prop:? AND stamp>=?:stamp:? LIMIT ?:limit:?'
+    getrows_by_prop_int_wmin = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE prop=?:prop:? AND intval=?:valu:? AND stamp>=?:stamp:? LIMIT ?:limit:?'
+    getrows_by_prop_str_wmin = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE prop=?:prop:? AND strval=?:valu:? AND stamp>=?:stamp:? LIMIT ?:limit:?'
+
+    getrows_by_prop_wmax = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE prop=?:prop:? AND stamp<?:stamp:? LIMIT ?:limit:?'
+    getrows_by_prop_int_wmax = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE prop=?:prop:? AND intval=?:valu:? AND stamp<?:stamp:? LIMIT ?:limit:?'
+    getrows_by_prop_str_wmax = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE prop=?:prop:? AND strval=?:valu:? AND stamp<?:stamp:? LIMIT ?:limit:?'
+
+    getrows_by_prop_wminmax = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE prop=?:prop:? AND stamp>=?:min:? AND stamp<?:max:? LIMIT ?:limit:?'
+    getrows_by_prop_int_wminmax = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE prop=?:prop:? AND intval=?:valu:? AND stamp>=?:min:? AND stamp<?:max:? LIMIT ?:limit:?'
+    getrows_by_prop_str_wminmax = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE prop=?:prop:? AND strval=?:valu:? AND stamp>=?:min:? AND stamp<?:max:? LIMIT ?:limit:?'
+    ################################################################################
+    getsize_by_prop = 'SELECT COUNT(*) FROM %s WHERE prop=?:prop:? LIMIT ?:limit:?'
+    getsize_by_prop_int = 'SELECT COUNT(*) FROM %s WHERE prop=?:prop:? AND intval=?:valu:? LIMIT ?:limit:?'
+    getsize_by_prop_str = 'SELECT COUNT(*) FROM %s WHERE prop=?:prop:? AND strval=?:valu:? LIMIT ?:limit:?'
+
+    getsize_by_prop_wmin = 'SELECT COUNT(*) FROM %s WHERE prop=?:prop:? AND stamp>=?:stamp:? LIMIT ?:limit:?'
+    getsize_by_prop_int_wmin = 'SELECT COUNT(*) FROM %s WHERE prop=?:prop:? AND intval=?:valu:? AND stamp>=?:stamp:? LIMIT ?:limit:?'
+    getsize_by_prop_str_wmin = 'SELECT COUNT(*) FROM %s WHERE prop=?:prop:? AND strval=?:valu:? AND stamp>=?:stamp:? LIMIT ?:limit:?'
+
+    getsize_by_prop_wmax = 'SELECT COUNT(*) FROM %s WHERE prop=?:prop:? AND stamp<?:stamp:? LIMIT ?:limit:?'
+    getsize_by_prop_int_wmax = 'SELECT COUNT(*) FROM %s WHERE prop=?:prop:? AND intval=?:valu:? AND stamp<?:stamp:? LIMIT ?:limit:?'
+    getsize_by_prop_str_wmax = 'SELECT COUNT(*) FROM %s WHERE prop=?:prop:? AND strval=?:valu:? AND stamp<?:stamp:? LIMIT ?:limit:?'
+
+    getsize_by_prop_wminmax = 'SELECT COUNT(*) FROM %s WHERE prop=?:prop:? AND stamp>=?:min:? AND stamp<?:max:? LIMIT ?:limit:?'
+    getsize_by_prop_int_wminmax = 'SELECT COUNT(*) FROM %s WHERE prop=?:prop:? AND intval=?:valu:? AND stamp>=?:min:? AND stamp<?:max:? LIMIT ?:limit:?'
+    getsize_by_prop_str_wminmax = 'SELECT COUNT(*) FROM %s WHERE prop=?:prop:? AND strval=?:valu:? AND stamp>=?:min:? AND stamp<?:max:? LIMIT ?:limit:?'
+    ################################################################################
+
+    getsize_by_range = 'SELECT COUNT(*) FROM %s WHERE prop=?:prop:? and intval>=?:min:? AND intval<?:max:? LIMIT ?:limit:?'
+    getsize_by_le = 'SELECT COUNT(*) FROM %s WHERE prop=?:prop:? and intval<=?:valu:? LIMIT ?:limit:?'
+    getsize_by_ge = 'SELECT COUNT(*) FROM %s WHERE prop=?:prop:? and intval>=?:valu:? LIMIT ?:limit:?'
+
+    delrows_by_id = 'DELETE FROM %s WHERE id=?:iden:?'
+    delrows_by_id_prop = 'DELETE FROM %s WHERE id=?:iden:? AND prop=?:prop:?'
+
+    ################################################################################
+    delrows_by_prop = 'DELETE FROM %s WHERE prop=?:prop:?'
+    delrows_by_prop_int = 'DELETE FROM %s WHERE prop=?:prop:? AND intval=?:valu:?'
+    delrows_by_prop_str = 'DELETE FROM %s WHERE prop=?:prop:? AND strval=?:valu:?'
+
+    delrows_by_prop_wmin = 'DELETE FROM %s WHERE prop=?:prop:? AND stamp>=?:stamp:?'
+    delrows_by_prop_int_wmin = 'DELETE FROM %s WHERE prop=?:prop:? AND intval=?:valu:? AND stamp>=?:stamp:?'
+    delrows_by_prop_str_wmin = 'DELETE FROM %s WHERE prop=?:prop:? AND strval=?:valu:? AND stamp>=?:stamp:?'
+
+    delrows_by_prop_wmax = 'DELETE FROM %s WHERE prop=?:prop:? AND stamp<?:stamp:?'
+    delrows_by_prop_int_wmax = 'DELETE FROM %s WHERE prop=?:prop:? AND intval=?:valu:? AND stamp<?:stamp:?'
+    delrows_by_prop_str_wmax = 'DELETE FROM %s WHERE prop=?:prop:? AND strval=?:valu:? AND stamp<?:stamp:?'
+
+    delrows_by_prop_wminmax = 'DELETE FROM %s WHERE prop=?:prop:? AND stamp>=?:min:? AND stamp<?:max:?'
+    delrows_by_prop_int_wminmax = 'DELETE FROM %s WHERE prop=?:prop:? AND intval=?:valu:? AND stamp>=?:min:? AND stamp<?:max:?'
+    delrows_by_prop_str_wminmax = 'DELETE FROM %s WHERE prop=?:prop:? AND strval=?:valu:? AND stamp>=?:min:? AND stamp<?:max:?'
+
+    ################################################################################
+    getjoin_by_prop = 'SELECT id,prop,strval,intval,stamp from %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? LIMIT ?:limit:?)'
+    getjoin_by_prop_int = 'SELECT id,prop,strval,intval,stamp from %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND intval=?:valu:? LIMIT ?:limit:?)'
+    getjoin_by_prop_str = 'SELECT id,prop,strval,intval,stamp from %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND strval=?:valu:? LIMIT ?:limit:?)'
+
+    getjoin_by_prop_wmin = 'SELECT id,prop,strval,intval,stamp from %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND stamp>=?:stamp:? LIMIT ?:limit:?)'
+    getjoin_by_prop_int_wmin = 'SELECT id,prop,strval,intval,stamp from %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND intval=?:valu:? AND stamp>=?:stamp:? LIMIT ?:limit:?)'
+    getjoin_by_prop_str_wmin = 'SELECT id,prop,strval,intval,stamp from %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND strval=?:valu:? AND stamp>=?:stamp:? LIMIT ?:limit:?)'
+
+    getjoin_by_prop_wmax = 'SELECT id,prop,strval,intval,stamp from %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND stamp<?:stamp:? LIMIT ?:limit:?)'
+    getjoin_by_prop_int_wmax = 'SELECT id,prop,strval,intval,stamp from %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND intval=?:valu:? AND stamp<?:stamp:? LIMIT ?:limit:?)'
+    getjoin_by_prop_str_wmax = 'SELECT id,prop,strval,intval,stamp from %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND strval=?:valu:? AND stamp<?:stamp:? LIMIT ?:limit:?)'
+
+    getjoin_by_prop_wminmax = 'SELECT id,prop,strval,intval,stamp from %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND stamp>=?:min:? AND stamp<?:max:? LIMIT ?:limit:?)'
+    getjoin_by_prop_int_wminmax = 'SELECT id,prop,strval,intval,stamp from %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND intval=?:valu:? AND stamp>=?:min:? AND stamp<?:max:? LIMIT ?:limit:?)'
+    getjoin_by_prop_str_wminmax = 'SELECT id,prop,strval,intval,stamp from %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND strval=?:valu:? AND stamp>=?:min:? AND stamp<?:max:? LIMIT ?:limit:?)'
+
+    getjoin_by_range_int = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? and ?:min:? <= intval AND intval<?:max:? LIMIT ?:limit:?)'
+    getjoin_by_range_str = 'SELECT id,prop,strval,intval,stamp FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? and ?:min:?<=strval AND strval<?:max:? LIMIT ?:limit:?)'
+
+    ################################################################################
+    deljoin_by_prop = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:?)'
+    deljoin_by_prop_int = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND intval=?:valu:?)'
+    deljoin_by_prop_str = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND strval=?:valu:?)'
+
+    deljoin_by_prop_wmin = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND stamp>=?:stamp:? )'
+    deljoin_by_prop_int_wmin = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND intval=?:valu:? AND stamp>=?:stamp:? )'
+    deljoin_by_prop_str_wmin = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND strval=?:valu:? AND stamp>=?:stamp:? )'
+
+    deljoin_by_prop_wmax = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND stamp<?:stamp:? )'
+    deljoin_by_prop_int_wmax = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND intval=?:valu:? AND stamp<?:stamp:? )'
+    deljoin_by_prop_str_wmax = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND strval=?:valu:? AND stamp<?:stamp:? )'
+
+    deljoin_by_prop_wminmax = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND stamp>=?:min:? AND stamp<?:max:?)'
+    deljoin_by_prop_int_wminmax = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND intval=?:valu:? AND stamp>=?:min:? AND stamp<?:max:?)'
+    deljoin_by_prop_str_wminmax = 'DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE prop=?:prop:? AND strval=?:valu:? AND stamp>=?:min:? AND stamp<?:max:?)'
+    ################################################################################
+
+    uprows_by_id_prop_str = 'UPDATE %s SET strval=?:valu:? WHERE id=?:iden:? and prop=?:prop:?'
+    uprows_by_id_prop_int = 'UPDATE %s SET intval=?:valu:? WHERE id=?:iden:? and prop=?:prop:?'
 
     def cursor(self):
         return self.dbpool.cursor()
@@ -222,7 +223,7 @@ class Cortex(common.Cortex):
         limit = self._getDbLimit(limit)
 
         q = self._q_getrows_by_range
-        args = [ prop, valu[0], valu[1], limit ]
+        args = { 'prop':prop, 'min':valu[0], 'max':valu[1], 'limit':limit }
 
         rows = self.select(q,args)
         return self._foldTypeCols(rows)
@@ -231,31 +232,31 @@ class Cortex(common.Cortex):
         limit = self._getDbLimit(limit)
         q = self._q_getrows_by_ge
 
-        rows = self.select(q, [ prop, valu, limit ])
+        rows = self.select(q, { 'prop':prop, 'valu':valu, 'limit':limit })
         return self._foldTypeCols(rows)
 
     def _rowsByLe(self, prop, valu, limit=None):
         limit = self._getDbLimit(limit)
         q = self._q_getrows_by_le
-        rows = self.select(q, [prop,valu,limit])
+        rows = self.select(q, { 'prop':prop, 'valu':valu, 'limit':limit })
         return self._foldTypeCols(rows)
 
     def _sizeByRange(self, prop, valu, limit=None):
         limit = self._getDbLimit(limit)
         q = self._q_getsize_by_range
-        args = [ prop, valu[0], valu[1], limit ]
+        args = { 'prop':prop, 'min':valu[0], 'max':valu[1], 'limit':limit }
         return self.select(q,args)[0][0]
 
     def _sizeByGe(self, prop, valu, limit=None):
         limit = self._getDbLimit(limit)
         q = self._q_getsize_by_ge
-        args = [ prop, valu, limit ]
+        args = { 'prop':prop, 'valu':valu, 'limit':limit }
         return self.select(q,args)[0][0]
 
     def _sizeByLe(self, prop, valu, limit=None):
         limit = self._getDbLimit(limit)
         q = self._q_getsize_by_le
-        args = [ prop, valu, limit ]
+        args = { 'prop':prop, 'valu':valu, 'limit':limit }
         return self.select(q,args)[0][0]
 
     def _initDbConn(self):
@@ -299,68 +300,69 @@ class Cortex(common.Cortex):
         # and all ? with db specific variable token
         tabtup = (table,) * query.count('%s')
         query = query % tabtup
-        query = query.replace('?',self.dbvar)
+        query = query.replace('?:',self.dbvar_open).replace(':?',self.dbvar_close)
         return query
 
     def _initCorQueries(self, table):
-        self._q_istable = istable
-        self._q_inittable = self._prepQuery(inittable, table)
-        self._q_init_id_idx = self._prepQuery(init_id_idx, table)
-        self._q_init_strval_idx = self._prepQuery(init_strval_idx, table)
-        self._q_init_intval_idx = self._prepQuery(init_intval_idx, table)
+        self._q_istable = self.istable
+        self._q_inittable = self._prepQuery(self.inittable, table)
+        self._q_init_id_idx = self._prepQuery(self.init_id_idx, table)
+        self._q_init_prop_idx = self._prepQuery(self.init_prop_idx, table)
+        self._q_init_strval_idx = self._prepQuery(self.init_strval_idx, table)
+        self._q_init_intval_idx = self._prepQuery(self.init_intval_idx, table)
 
-        self._q_addrows = self._prepQuery(addrows, table)
-        self._q_getrows_by_id = self._prepQuery(getrows_by_id, table)
-        self._q_getrows_by_range = self._prepQuery(getrows_by_range, table)
-        self._q_getrows_by_ge = self._prepQuery(getrows_by_ge, table)
-        self._q_getrows_by_le = self._prepQuery(getrows_by_le, table)
-        self._q_getrows_by_id_prop = self._prepQuery(getrows_by_id_prop, table)
+        self._q_addrows = self._prepQuery(self.addrows, table)
+        self._q_getrows_by_id = self._prepQuery(self.getrows_by_id, table)
+        self._q_getrows_by_range = self._prepQuery(self.getrows_by_range, table)
+        self._q_getrows_by_ge = self._prepQuery(self.getrows_by_ge, table)
+        self._q_getrows_by_le = self._prepQuery(self.getrows_by_le, table)
+        self._q_getrows_by_id_prop = self._prepQuery(self.getrows_by_id_prop, table)
 
         ###################################################################################
-        self._q_getrows_by_prop = self._prepQuery(getrows_by_prop, table)
-        self._q_getrows_by_prop_wmin = self._prepQuery(getrows_by_prop_wmin, table)
-        self._q_getrows_by_prop_wmax = self._prepQuery(getrows_by_prop_wmax, table)
-        self._q_getrows_by_prop_wminmax = self._prepQuery(getrows_by_prop_wminmax, table)
+        self._q_getrows_by_prop = self._prepQuery(self.getrows_by_prop, table)
+        self._q_getrows_by_prop_wmin = self._prepQuery(self.getrows_by_prop_wmin, table)
+        self._q_getrows_by_prop_wmax = self._prepQuery(self.getrows_by_prop_wmax, table)
+        self._q_getrows_by_prop_wminmax = self._prepQuery(self.getrows_by_prop_wminmax, table)
         ###################################################################################
-        self._q_getrows_by_prop_int = self._prepQuery(getrows_by_prop_int, table)
-        self._q_getrows_by_prop_int_wmin = self._prepQuery(getrows_by_prop_int_wmin, table)
-        self._q_getrows_by_prop_int_wmax = self._prepQuery(getrows_by_prop_int_wmax, table)
-        self._q_getrows_by_prop_int_wminmax = self._prepQuery(getrows_by_prop_int_wminmax, table)
+        self._q_getrows_by_prop_int = self._prepQuery(self.getrows_by_prop_int, table)
+        self._q_getrows_by_prop_int_wmin = self._prepQuery(self.getrows_by_prop_int_wmin, table)
+        self._q_getrows_by_prop_int_wmax = self._prepQuery(self.getrows_by_prop_int_wmax, table)
+        self._q_getrows_by_prop_int_wminmax = self._prepQuery(self.getrows_by_prop_int_wminmax, table)
         ###################################################################################
-        self._q_getrows_by_prop_str = self._prepQuery(getrows_by_prop_str, table)
-        self._q_getrows_by_prop_str_wmin = self._prepQuery(getrows_by_prop_str_wmin, table)
-        self._q_getrows_by_prop_str_wmax = self._prepQuery(getrows_by_prop_str_wmax, table)
-        self._q_getrows_by_prop_str_wminmax = self._prepQuery(getrows_by_prop_str_wminmax, table)
+        self._q_getrows_by_prop_str = self._prepQuery(self.getrows_by_prop_str, table)
+        self._q_getrows_by_prop_str_wmin = self._prepQuery(self.getrows_by_prop_str_wmin, table)
+        self._q_getrows_by_prop_str_wmax = self._prepQuery(self.getrows_by_prop_str_wmax, table)
+        self._q_getrows_by_prop_str_wminmax = self._prepQuery(self.getrows_by_prop_str_wminmax, table)
         ###################################################################################
-        self._q_getjoin_by_prop = self._prepQuery(getjoin_by_prop, table)
-        self._q_getjoin_by_prop_wmin = self._prepQuery(getjoin_by_prop_wmin, table)
-        self._q_getjoin_by_prop_wmax = self._prepQuery(getjoin_by_prop_wmax, table)
-        self._q_getjoin_by_prop_wminmax = self._prepQuery(getjoin_by_prop_wminmax, table)
+        self._q_getjoin_by_prop = self._prepQuery(self.getjoin_by_prop, table)
+        self._q_getjoin_by_prop_wmin = self._prepQuery(self.getjoin_by_prop_wmin, table)
+        self._q_getjoin_by_prop_wmax = self._prepQuery(self.getjoin_by_prop_wmax, table)
+        self._q_getjoin_by_prop_wminmax = self._prepQuery(self.getjoin_by_prop_wminmax, table)
         ###################################################################################
-        self._q_getjoin_by_prop_int = self._prepQuery(getjoin_by_prop_int, table)
-        self._q_getjoin_by_prop_int_wmin = self._prepQuery(getjoin_by_prop_int_wmin, table)
-        self._q_getjoin_by_prop_int_wmax = self._prepQuery(getjoin_by_prop_int_wmax, table)
-        self._q_getjoin_by_prop_int_wminmax = self._prepQuery(getjoin_by_prop_int_wminmax, table)
+        self._q_getjoin_by_prop_int = self._prepQuery(self.getjoin_by_prop_int, table)
+        self._q_getjoin_by_prop_int_wmin = self._prepQuery(self.getjoin_by_prop_int_wmin, table)
+        self._q_getjoin_by_prop_int_wmax = self._prepQuery(self.getjoin_by_prop_int_wmax, table)
+        self._q_getjoin_by_prop_int_wminmax = self._prepQuery(self.getjoin_by_prop_int_wminmax, table)
         ###################################################################################
-        self._q_getjoin_by_prop_str = self._prepQuery(getjoin_by_prop_str, table)
-        self._q_getjoin_by_prop_str_wmin = self._prepQuery(getjoin_by_prop_str_wmin, table)
-        self._q_getjoin_by_prop_str_wmax = self._prepQuery(getjoin_by_prop_str_wmax, table)
-        self._q_getjoin_by_prop_str_wminmax = self._prepQuery(getjoin_by_prop_str_wminmax, table)
+        self._q_getjoin_by_prop_str = self._prepQuery(self.getjoin_by_prop_str, table)
+        self._q_getjoin_by_prop_str_wmin = self._prepQuery(self.getjoin_by_prop_str_wmin, table)
+        self._q_getjoin_by_prop_str_wmax = self._prepQuery(self.getjoin_by_prop_str_wmax, table)
+        self._q_getjoin_by_prop_str_wminmax = self._prepQuery(self.getjoin_by_prop_str_wminmax, table)
         ###################################################################################
-        self._q_getsize_by_prop = self._prepQuery(getsize_by_prop, table)
-        self._q_getsize_by_prop_wmin = self._prepQuery(getsize_by_prop_wmin, table)
-        self._q_getsize_by_prop_wmax = self._prepQuery(getsize_by_prop_wmax, table)
-        self._q_getsize_by_prop_wminmax = self._prepQuery(getsize_by_prop_wminmax, table)
+        self._q_getsize_by_prop = self._prepQuery(self.getsize_by_prop, table)
+        self._q_getsize_by_prop_wmin = self._prepQuery(self.getsize_by_prop_wmin, table)
+        self._q_getsize_by_prop_wmax = self._prepQuery(self.getsize_by_prop_wmax, table)
+        self._q_getsize_by_prop_wminmax = self._prepQuery(self.getsize_by_prop_wminmax, table)
         ###################################################################################
-        self._q_getsize_by_prop_int = self._prepQuery(getsize_by_prop_int, table)
-        self._q_getsize_by_prop_int_wmin = self._prepQuery(getsize_by_prop_int_wmin, table)
-        self._q_getsize_by_prop_int_wmax = self._prepQuery(getsize_by_prop_int_wmax, table)
-        self._q_getsize_by_prop_int_wminmax = self._prepQuery(getsize_by_prop_int_wminmax, table)
+        self._q_getsize_by_prop_int = self._prepQuery(self.getsize_by_prop_int, table)
+        self._q_getsize_by_prop_int_wmin = self._prepQuery(self.getsize_by_prop_int_wmin, table)
+        self._q_getsize_by_prop_int_wmax = self._prepQuery(self.getsize_by_prop_int_wmax, table)
+        self._q_getsize_by_prop_int_wminmax = self._prepQuery(self.getsize_by_prop_int_wminmax, table)
         ###################################################################################
-        self._q_getsize_by_prop_str = self._prepQuery(getsize_by_prop_str, table)
-        self._q_getsize_by_prop_str_wmin = self._prepQuery(getsize_by_prop_str_wmin, table)
-        self._q_getsize_by_prop_str_wmax = self._prepQuery(getsize_by_prop_str_wmax, table)
-        self._q_getsize_by_prop_str_wminmax = self._prepQuery(getsize_by_prop_str_wminmax, table)
+        self._q_getsize_by_prop_str = self._prepQuery(self.getsize_by_prop_str, table)
+        self._q_getsize_by_prop_str_wmin = self._prepQuery(self.getsize_by_prop_str_wmin, table)
+        self._q_getsize_by_prop_str_wmax = self._prepQuery(self.getsize_by_prop_str_wmax, table)
+        self._q_getsize_by_prop_str_wminmax = self._prepQuery(self.getsize_by_prop_str_wminmax, table)
         ###################################################################################
 
         self.qbuild = {
@@ -413,53 +415,53 @@ class Cortex(common.Cortex):
                 (str_t,int_t,int_t):self._q_getsize_by_prop_str_wminmax,
             },
             'delrowsbyprop':{
-                (none_t,none_t,none_t):self._prepQuery(delrows_by_prop, table),
-                (none_t,int_t,none_t):self._prepQuery(delrows_by_prop_wmin, table),
-                (none_t,none_t,int_t):self._prepQuery(delrows_by_prop_wmax, table),
-                (none_t,int_t,int_t):self._prepQuery(delrows_by_prop_wminmax, table),
+                (none_t,none_t,none_t):self._prepQuery(self.delrows_by_prop, table),
+                (none_t,int_t,none_t):self._prepQuery(self.delrows_by_prop_wmin, table),
+                (none_t,none_t,int_t):self._prepQuery(self.delrows_by_prop_wmax, table),
+                (none_t,int_t,int_t):self._prepQuery(self.delrows_by_prop_wminmax, table),
 
-                (int_t,none_t,none_t):self._prepQuery(delrows_by_prop_int, table),
-                (int_t,int_t,none_t):self._prepQuery(delrows_by_prop_int_wmin, table),
-                (int_t,none_t,int_t):self._prepQuery(delrows_by_prop_int_wmax, table),
-                (int_t,int_t,int_t):self._prepQuery(delrows_by_prop_int_wminmax, table),
+                (int_t,none_t,none_t):self._prepQuery(self.delrows_by_prop_int, table),
+                (int_t,int_t,none_t):self._prepQuery(self.delrows_by_prop_int_wmin, table),
+                (int_t,none_t,int_t):self._prepQuery(self.delrows_by_prop_int_wmax, table),
+                (int_t,int_t,int_t):self._prepQuery(self.delrows_by_prop_int_wminmax, table),
 
-                (str_t,none_t,none_t):self._prepQuery(delrows_by_prop_str, table),
-                (str_t,int_t,none_t):self._prepQuery(delrows_by_prop_str_wmin, table),
-                (str_t,none_t,int_t):self._prepQuery(delrows_by_prop_str_wmax, table),
-                (str_t,int_t,int_t):self._prepQuery(delrows_by_prop_str_wminmax, table),
+                (str_t,none_t,none_t):self._prepQuery(self.delrows_by_prop_str, table),
+                (str_t,int_t,none_t):self._prepQuery(self.delrows_by_prop_str_wmin, table),
+                (str_t,none_t,int_t):self._prepQuery(self.delrows_by_prop_str_wmax, table),
+                (str_t,int_t,int_t):self._prepQuery(self.delrows_by_prop_str_wminmax, table),
             },
             'deljoinbyprop':{
-                (none_t,none_t,none_t):self._prepQuery(deljoin_by_prop, table),
-                (none_t,int_t,none_t):self._prepQuery(deljoin_by_prop_wmin, table),
-                (none_t,none_t,int_t):self._prepQuery(deljoin_by_prop_wmax, table),
-                (none_t,int_t,int_t):self._prepQuery(deljoin_by_prop_wminmax, table),
+                (none_t,none_t,none_t):self._prepQuery(self.deljoin_by_prop, table),
+                (none_t,int_t,none_t):self._prepQuery(self.deljoin_by_prop_wmin, table),
+                (none_t,none_t,int_t):self._prepQuery(self.deljoin_by_prop_wmax, table),
+                (none_t,int_t,int_t):self._prepQuery(self.deljoin_by_prop_wminmax, table),
 
-                (int_t,none_t,none_t):self._prepQuery(deljoin_by_prop_int, table),
-                (int_t,int_t,none_t):self._prepQuery(deljoin_by_prop_int_wmin, table),
-                (int_t,none_t,int_t):self._prepQuery(deljoin_by_prop_int_wmax, table),
-                (int_t,int_t,int_t):self._prepQuery(deljoin_by_prop_int_wminmax, table),
+                (int_t,none_t,none_t):self._prepQuery(self.deljoin_by_prop_int, table),
+                (int_t,int_t,none_t):self._prepQuery(self.deljoin_by_prop_int_wmin, table),
+                (int_t,none_t,int_t):self._prepQuery(self.deljoin_by_prop_int_wmax, table),
+                (int_t,int_t,int_t):self._prepQuery(self.deljoin_by_prop_int_wminmax, table),
 
-                (str_t,none_t,none_t):self._prepQuery(deljoin_by_prop_str, table),
-                (str_t,int_t,none_t):self._prepQuery(deljoin_by_prop_str_wmin, table),
-                (str_t,none_t,int_t):self._prepQuery(deljoin_by_prop_str_wmax, table),
-                (str_t,int_t,int_t):self._prepQuery(deljoin_by_prop_str_wminmax, table),
+                (str_t,none_t,none_t):self._prepQuery(self.deljoin_by_prop_str, table),
+                (str_t,int_t,none_t):self._prepQuery(self.deljoin_by_prop_str_wmin, table),
+                (str_t,none_t,int_t):self._prepQuery(self.deljoin_by_prop_str_wmax, table),
+                (str_t,int_t,int_t):self._prepQuery(self.deljoin_by_prop_str_wminmax, table),
             }
         }
 
-        self._q_getsize_by_prop = self._prepQuery(getsize_by_prop, table)
+        self._q_getsize_by_prop = self._prepQuery(self.getsize_by_prop, table)
 
-        self._q_getsize_by_ge = self._prepQuery(getsize_by_ge, table)
-        self._q_getsize_by_le = self._prepQuery(getsize_by_le, table)
-        self._q_getsize_by_range = self._prepQuery(getsize_by_range, table)
+        self._q_getsize_by_ge = self._prepQuery(self.getsize_by_ge, table)
+        self._q_getsize_by_le = self._prepQuery(self.getsize_by_le, table)
+        self._q_getsize_by_range = self._prepQuery(self.getsize_by_range, table)
 
-        self._q_delrows_by_id = self._prepQuery(delrows_by_id, table)
-        self._q_delrows_by_id_prop = self._prepQuery(delrows_by_id_prop, table)
+        self._q_delrows_by_id = self._prepQuery(self.delrows_by_id, table)
+        self._q_delrows_by_id_prop = self._prepQuery(self.delrows_by_id_prop, table)
 
-        self._q_uprows_by_id_prop_str = self._prepQuery(uprows_by_id_prop_str, table)
-        self._q_uprows_by_id_prop_int = self._prepQuery(uprows_by_id_prop_int, table)
+        self._q_uprows_by_id_prop_str = self._prepQuery(self.uprows_by_id_prop_str, table)
+        self._q_uprows_by_id_prop_int = self._prepQuery(self.uprows_by_id_prop_int, table)
 
-        self._q_getjoin_by_range_str = self._prepQuery(getjoin_by_range_str, table)
-        self._q_getjoin_by_range_int = self._prepQuery(getjoin_by_range_int, table)
+        self._q_getjoin_by_range_str = self._prepQuery(self.getjoin_by_range_str, table)
+        self._q_getjoin_by_range_int = self._prepQuery(self.getjoin_by_range_int, table)
 
     def _checkForTable(self, name):
         return len(self.select(self._q_istable,(name,)))
@@ -468,11 +470,12 @@ class Cortex(common.Cortex):
         with self.cursor() as c:
             c.execute(self._q_inittable)
             c.execute(self._q_init_id_idx)
+            c.execute(self._q_init_prop_idx)
             c.execute(self._q_init_strval_idx)
             c.execute(self._q_init_intval_idx)
 
     def _addRows(self, rows):
-        rows = [ (i,p,None,v,t) if s_compat.isint(v) else (i,p,v,None,t) for i,p,v,t in rows ]
+        rows = [ {'iden':i,'prop':p,'strval':None,'intval':v,'stamp':t} if s_compat.isint(v) else {'iden':i,'prop':p,'strval':v,'intval':None,'stamp':t} for i,p,v,t in rows ]
         with self.cursor() as c:
             c.executemany( self._q_addrows, rows )
 
@@ -504,11 +507,11 @@ class Cortex(common.Cortex):
                 ret.append( (ident,prop,intval,stamp) )
             else:
                 ret.append( (ident,prop,strval,stamp) )
-                
+
         return ret
 
     def _getRowsById(self, ident):
-        rows = self.select(self._q_getrows_by_id,(ident,))
+        rows = self.select(self._q_getrows_by_id,{'iden':ident})
         return self._foldTypeCols(rows)
 
     def _getSizeByProp(self, prop, valu=None, limit=None, mintime=None, maxtime=None):
@@ -544,7 +547,7 @@ class Cortex(common.Cortex):
         else:
             q = self._q_getjoin_by_range_str
 
-        args = [ prop, valus[0], valus[1], limit ]
+        args = { 'prop':prop, 'min':valus[0], 'max':valus[1], 'limit':limit }
 
         rows = self.select(q,args)
         rows = self._foldTypeCols(rows)
@@ -555,11 +558,11 @@ class Cortex(common.Cortex):
 
         qkey = (s_compat.typeof(valu),s_compat.typeof(mintime),s_compat.typeof(maxtime))
 
-        qargs = [ prop ]
-        qargs.extend( [ v for v in (valu,mintime,maxtime) if v != None ] )
+        qargs = { 'prop':prop }
+        qargs.update( { k:v for k,v in {'valu':valu,'min':mintime,'max':maxtime}.items() if v is not None } )
 
         if not nolim:
-            qargs.append(limit)
+            qargs['limit'] = limit
 
         qstr = self.qbuild[name][qkey]
         #print('QNAM: %r' % (name,))
@@ -575,24 +578,24 @@ class Cortex(common.Cortex):
         return rows
 
     def _delRowsByIdProp(self, ident, prop):
-        self.delete( self._q_delrows_by_id_prop, (ident,prop))
+        self.delete( self._q_delrows_by_id_prop, {'iden':ident,'prop':prop})
 
     def _getRowsByIdProp(self, iden, prop):
-        rows = self.select( self._q_getrows_by_id_prop, (iden,prop))
+        rows = self.select( self._q_getrows_by_id_prop, {'iden':iden,'prop':prop})
         return self._foldTypeCols(rows)
 
     def _setRowsByIdProp(self, ident, prop, valu):
         if s_compat.isint(valu):
-            count = self.update( self._q_uprows_by_id_prop_int, (valu,ident,prop) )
+            count = self.update( self._q_uprows_by_id_prop_int, {'valu':valu,'iden':ident,'prop':prop} )
         else:
-            count = self.update( self._q_uprows_by_id_prop_str, (valu,ident,prop) )
+            count = self.update( self._q_uprows_by_id_prop_str, {'valu':valu,'iden':ident,'prop':prop} )
 
         if count == 0:
-            rows = [ (ident,prop,valu,int(time.time())), ]
+            rows = [ (ident,prop,valu,int(time.time())) ]
             self._addRows(rows)
 
     def _delRowsById(self, ident):
-        self.delete(self._q_delrows_by_id,(ident,))
+        self.delete(self._q_delrows_by_id,{'iden':ident})
 
     def _delJoinByProp(self, prop, valu=None, mintime=None, maxtime=None):
         self._runPropQuery('deljoinbyprop',prop,valu=valu,mintime=mintime,maxtime=maxtime,meth=self.delete, nolim=True)


### PR DESCRIPTION
… index column width limit.

Postgres 9.5 has a limit of 2712 for index column values. When a strval exceeds this, psycopg2 throws an exception:
```
ERROR auditItem.upsert formTufoByFrob exception: index row size 3856 exceeds maximum 2712 for index "flash_audititem_strval_idx"
HINT:  Values larger than 1/3 of a buffer page cannot be indexed.
```
This changes the postgres core to index on md5(strval) and changes all queries to query by `md5(strval)=md5(valu) AND strval=valu`.

To do this I had to change the sqlite core (parent class of postgres) to pass query parameters by name instead of by position and change the way parameters are referenced in queries.