### PR TITLE
cortex: add addDataModel method

### DIFF
--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -257,6 +257,32 @@ class Cortex(EventBus,DataModel,ConfigMixin):
         for item in self.getTufosByProp('syn:prop'):
             self._initPropTufo(item)
 
+    def addDataModel(self, modname, modl):
+        '''
+        Store all types/forms/props from the given data model in the cortex.
+        This should be done on initialization of an empty cortex only.
+
+        Example:
+
+            modname = 'synapse.models.foo'
+            core.addDataModel(modname, s_dyndep.tryDynFunc(modname, 'getDataModel'))
+        '''
+        vers = modl.get('version',0)
+        item = self.formTufoByProp('syn:model',modname,version=vers)
+
+        for name,info in modl.get('types',()):
+            print(name)
+            print(self.formTufoByProp('syn:type',name,**info))
+
+        # load all forms after loading all types
+        for name,info,props in modl.get('forms',()):
+            self.formTufoByProp('syn:form',name,**info)
+
+            for prop,pnfo in props:
+                pnfo['form'] = name
+                fullprop = '%s:%s' % (name,prop)
+                self.formTufoByProp('syn:prop',fullprop,**pnfo)
+
     def _getTufosByCache(self, prop, valu, limit):
         # only used if self.caching = 1
         ckey = (prop,valu,limit) # cache key

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -265,7 +265,7 @@ class Cortex(EventBus,DataModel,ConfigMixin):
         Example:
 
             modname = 'synapse.models.foo'
-            core.addDataModel(modname, s_dyndep.tryDynFunc(modname, 'getDataModel'))
+            core.addDataModel(modname, s_dyndep.tryDynFunc(modname+'.getDataModel'))
         '''
         vers = modl.get('version',0)
         item = self.formTufoByProp('syn:model',modname,version=vers)

--- a/synapse/cores/common.py
+++ b/synapse/cores/common.py
@@ -271,8 +271,7 @@ class Cortex(EventBus,DataModel,ConfigMixin):
         item = self.formTufoByProp('syn:model',modname,version=vers)
 
         for name,info in modl.get('types',()):
-            print(name)
-            print(self.formTufoByProp('syn:type',name,**info))
+            self.formTufoByProp('syn:type',name,**info)
 
         # load all forms after loading all types
         for name,info,props in modl.get('forms',()):

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1181,3 +1181,31 @@ class CortexTest(SynTest):
 
                     self.eq( len(core.getTufosByTag('inet:fqdn', 'foo.bar')), 0 )
                     self.eq( len(core.getTufosByTag('inet:fqdn', 'foo')), 1)
+
+    def test_cortex_addmodel(self):
+        with s_cortex.openurl('ram://') as core:
+            core.addDataModel('a.foo.module',
+                {
+                    'prefix':'foo',
+                    'version':201612201147,
+
+                    'types':(
+                        ('foo:bar',{'subof':'str:lwr'}),
+                    ),
+
+                    'forms':(
+                        ('foo:baz',{'ptype':'foo:bar'},[
+                            ('faz',{'ptype':'str:lwr'}),
+                        ]),
+                    ),
+                })
+
+            tuf0 = core.formTufoByFrob('foo:baz', 'AAA', faz='BBB')
+            self.eq( tuf0[1].get('foo:baz'), 'aaa' )
+            self.eq( tuf0[1].get('foo:baz:faz'), 'bbb' )
+
+            self.assertIsNotNone( core.getTufoByProp('syn:model', 'a.foo.module') )
+            self.assertIsNotNone( core.getTufoByProp('syn:type', 'foo:bar') )
+            self.assertIsNotNone( core.getTufoByProp('syn:form', 'foo:baz') )
+            self.assertIsNotNone( core.getTufoByProp('syn:prop', 'foo:baz:faz') )
+

--- a/synapse/tests/test_cortex.py
+++ b/synapse/tests/test_cortex.py
@@ -1209,3 +1209,29 @@ class CortexTest(SynTest):
             self.assertIsNotNone( core.getTufoByProp('syn:form', 'foo:baz') )
             self.assertIsNotNone( core.getTufoByProp('syn:prop', 'foo:baz:faz') )
 
+        with s_cortex.openurl('ram://') as core:
+            core.addDataModels([('a.foo.module',
+                {
+                    'prefix':'foo',
+                    'version':201612201147,
+
+                    'types':(
+                        ('foo:bar',{'subof':'str:lwr'}),
+                    ),
+
+                    'forms':(
+                        ('foo:baz',{'ptype':'foo:bar'},[
+                            ('faz',{'ptype':'str:lwr'}),
+                        ]),
+                    ),
+                })])
+
+            tuf0 = core.formTufoByFrob('foo:baz', 'AAA', faz='BBB')
+            self.eq( tuf0[1].get('foo:baz'), 'aaa' )
+            self.eq( tuf0[1].get('foo:baz:faz'), 'bbb' )
+
+            self.assertIsNotNone( core.getTufoByProp('syn:model', 'a.foo.module') )
+            self.assertIsNotNone( core.getTufoByProp('syn:type', 'foo:bar') )
+            self.assertIsNotNone( core.getTufoByProp('syn:form', 'foo:baz') )
+            self.assertIsNotNone( core.getTufoByProp('syn:prop', 'foo:baz:faz') )
+


### PR DESCRIPTION
first pass at adding a cortex-level routine for registering data models.