### PR TITLE
init inet model before dns model

### DIFF
--- a/synapse/__init__.py
+++ b/synapse/__init__.py
@@ -17,9 +17,9 @@ import synapse.lib.modules as s_modules
 
 # load all the synapse builtin modules
 s_modules.load('synapse.models.syn')
+s_modules.load('synapse.models.inet')
 s_modules.load('synapse.models.dns')
 s_modules.load('synapse.models.orgs')
-s_modules.load('synapse.models.inet')
 s_modules.load('synapse.models.mime')
 s_modules.load('synapse.models.money')
 s_modules.load('synapse.models.telco')


### PR DESCRIPTION
yeah, i know its not as pretty, but dns relies on inet types.

when i went digging into some of my own model errors, i found the following when printing out type ctor exceptions:

```
comp: dns:a
WARNING:synapse.lib.types:help
Traceback (most recent call last):
  File "/code/synapse/synapse/lib/types.py", line 239, in __init__
    tobj = self.tlib.reqDataType(tnam)
  File "/code/synapse/synapse/lib/types.py", line 517, in reqDataType
    raise NoSuchType(name=name)
synapse.exc.NoSuchType: NoSuchType: name='inet:fqdn'
comp: dns:ns
WARNING:synapse.lib.types:help
Traceback (most recent call last):
  File "/code/synapse/synapse/lib/types.py", line 239, in __init__
    tobj = self.tlib.reqDataType(tnam)
  File "/code/synapse/synapse/lib/types.py", line 517, in reqDataType
    raise NoSuchType(name=name)
synapse.exc.NoSuchType: NoSuchType: name='inet:fqdn'
comp: dns:rev
WARNING:synapse.lib.types:help
Traceback (most recent call last):
  File "/code/synapse/synapse/lib/types.py", line 239, in __init__
    tobj = self.tlib.reqDataType(tnam)
  File "/code/synapse/synapse/lib/types.py", line 517, in reqDataType
    raise NoSuchType(name=name)
synapse.exc.NoSuchType: NoSuchType: name='inet:ipv4'
```

this is how i stumbled across the bug. it wasn't easy, since `TypeLib.addType()` swallows ctor errors: https://github.com/vivisect/synapse/blob/19601268eaa5341534184f4a37e515556bd986cf/synapse/lib/types.py#L529 

can we also add some logging there, or better handle the case when a type ctor fails?