### PR TITLE
types: add reverse option to SeprType

### DIFF
--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -304,6 +304,7 @@ class SeprType(CompType):
         CompType.__init__(self, tlib, name, **info)
         self.sepr = info.get('sep',',')
         self.lower = info.get('lower',0)
+        self.reverse = info.get('reverse',0)
 
     def norm(self, valu, oldval=None):
         reprs = []
@@ -311,7 +312,10 @@ class SeprType(CompType):
         if self.lower:
             valu = valu.lower()
 
-        parts = valu.split(self.sepr,len(self.fields))
+        if self.reverse:
+            parts = valu.rsplit(self.sepr,len(self.fields)-1)
+        else:
+            parts = valu.split(self.sepr,len(self.fields)-1)
         for part,(name,tobj) in self._zipvals(parts):
             reprs.append( tobj.repr(tobj.parse(part)) )
         return self.sepr.join(reprs)
@@ -321,7 +325,10 @@ class SeprType(CompType):
 
     def chop(self, valu):
         subs = {}
-        parts = valu.split(self.sepr,len(self.fields))
+        if self.reverse:
+            parts = valu.rsplit(self.sepr,len(self.fields)-1)
+        else:
+            parts = valu.split(self.sepr,len(self.fields)-1)
 
         if self.lower:
             valu = valu.lower()

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -342,3 +342,12 @@ class DataTypesTest(SynTest):
         with s_cortex.openurl('ram:///') as core:
             core.addType('foo:bar',subof='inet:ipv4')
             self.assertIsNotNone( core.getTypeInfo('foo:bar','ex') )
+
+    def test_type_sepr_reverse(self):
+        tlib = s_types.TypeLib()
+
+        tlib.addType('foo',subof='sepr',sep='/',fields='first,str:lwr|rest,str:lwr',reverse=1)
+        foo = tlib.getTypeChop('foo','/home/user/Downloads')
+        self.eq( foo[1].get('first'), '/home/user' )
+        self.eq( foo[1].get('rest'), 'downloads' )
+


### PR DESCRIPTION
add an option to `SeprType` that splits the source string from right-to-left (vs the default left-to-right). this is useful when the number of fields is smaller than the number of possible splits (like, splitting the directory and filename in `/home/user/Downloads` by `/`).