### PR TITLE
types: add recursive option to SeprType

### DIFF
--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -313,6 +313,7 @@ class SeprType(CompType):
         self.lower = info.get('lower',0)
         self.recursive = info.get('recursive',0)
         self.reverse = info.get('reverse',0)
+        self.strictfields = info.get('strictfields',1)
 
     def norm(self, valu, oldval=None):
         reprs = []
@@ -327,6 +328,10 @@ class SeprType(CompType):
 
         if self.recursive:
             for part,(name,tobj) in self._zipvals(parts):
+
+                if part == None and not self.strictfields:
+                    continue
+
                 if tobj == self:
                     # do not recursively norm
                     reprs.append(part)
@@ -336,6 +341,8 @@ class SeprType(CompType):
 
         else:
             for part,(name,tobj) in self._zipvals(parts):
+                if part == None and not self.strictfields:
+                    continue
                 reprs.append( tobj.repr(tobj.parse(part)) )
             return self.sepr.join(reprs)
 
@@ -357,6 +364,9 @@ class SeprType(CompType):
         if self.recursive:
             for part,(name,tobj) in self._zipvals(parts):
 
+                if part == None and not self.strictfields:
+                    continue
+
                 if tobj == self:
                     # do not recursively chop
                     norm, nsub = part, {}
@@ -371,6 +381,10 @@ class SeprType(CompType):
                     subs['%s:%s' % (name,subn)] = subv
         else:
             for part,(name,tobj) in self._zipvals(parts):
+
+                if part == None and not self.strictfields:
+                    continue
+
                 norm = tobj.parse(part)
                 norm,nsub = tobj.chop(norm)
 
@@ -379,6 +393,7 @@ class SeprType(CompType):
                 subs[name] = norm
                 for subn,subv in nsub.items():
                     subs['%s:%s' % (name,subn)] = subv
+
 
         return self.sepr.join(reprs),subs
 

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -313,7 +313,6 @@ class SeprType(CompType):
         self.lower = info.get('lower',0)
         self.recursive = info.get('recursive',0)
         self.reverse = info.get('reverse',0)
-        self.strictfields = info.get('strictfields',1)
 
     def norm(self, valu, oldval=None):
         reprs = []
@@ -328,10 +327,6 @@ class SeprType(CompType):
 
         if self.recursive:
             for part,(name,tobj) in self._zipvals(parts):
-
-                if part == None and not self.strictfields:
-                    continue
-
                 if tobj == self:
                     # do not recursively norm
                     reprs.append(part)
@@ -341,8 +336,6 @@ class SeprType(CompType):
 
         else:
             for part,(name,tobj) in self._zipvals(parts):
-                if part == None and not self.strictfields:
-                    continue
                 reprs.append( tobj.repr(tobj.parse(part)) )
             return self.sepr.join(reprs)
 
@@ -364,9 +357,6 @@ class SeprType(CompType):
         if self.recursive:
             for part,(name,tobj) in self._zipvals(parts):
 
-                if part == None and not self.strictfields:
-                    continue
-
                 if tobj == self:
                     # do not recursively chop
                     norm, nsub = part, {}
@@ -381,10 +371,6 @@ class SeprType(CompType):
                     subs['%s:%s' % (name,subn)] = subv
         else:
             for part,(name,tobj) in self._zipvals(parts):
-
-                if part == None and not self.strictfields:
-                    continue
-
                 norm = tobj.parse(part)
                 norm,nsub = tobj.chop(norm)
 
@@ -393,7 +379,6 @@ class SeprType(CompType):
                 subs[name] = norm
                 for subn,subv in nsub.items():
                     subs['%s:%s' % (name,subn)] = subv
-
 
         return self.sepr.join(reprs),subs
 

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -311,7 +311,6 @@ class SeprType(CompType):
         CompType.__init__(self, tlib, name, **info)
         self.sepr = info.get('sep',',')
         self.lower = info.get('lower',0)
-        self.recursive = info.get('recursive',0)
         self.reverse = info.get('reverse',0)
 
     def norm(self, valu, oldval=None):
@@ -325,19 +324,13 @@ class SeprType(CompType):
         else:
             parts = valu.split(self.sepr,len(self.fields)-1)
 
-        if self.recursive:
-            for part,(name,tobj) in self._zipvals(parts):
-                if tobj == self:
-                    # do not recursively norm
-                    reprs.append(part)
-                else:
-                    reprs.append( tobj.repr(tobj.parse(part)) )
-            return self.sepr.join(reprs)
-
-        else:
-            for part,(name,tobj) in self._zipvals(parts):
+        for part,(name,tobj) in self._zipvals(parts):
+            if tobj == self:
+                # do not recursively norm
+                reprs.append(part)
+            else:
                 reprs.append( tobj.repr(tobj.parse(part)) )
-            return self.sepr.join(reprs)
+        return self.sepr.join(reprs)
 
     def repr(self, valu):
         return valu
@@ -354,31 +347,20 @@ class SeprType(CompType):
 
         reprs = []
 
-        if self.recursive:
-            for part,(name,tobj) in self._zipvals(parts):
+        for part,(name,tobj) in self._zipvals(parts):
 
-                if tobj == self:
-                    # do not recursively chop
-                    norm, nsub = part, {}
-                    reprs.append(norm)
-                else:
-                    norm = tobj.parse(part)
-                    norm,nsub = tobj.chop(norm)
-                    reprs.append(tobj.repr(norm))
-
-                subs[name] = norm
-                for subn,subv in nsub.items():
-                    subs['%s:%s' % (name,subn)] = subv
-        else:
-            for part,(name,tobj) in self._zipvals(parts):
+            if tobj == self:
+                # do not recursively chop
+                norm, nsub = part, {}
+                reprs.append(norm)
+            else:
                 norm = tobj.parse(part)
                 norm,nsub = tobj.chop(norm)
-
                 reprs.append(tobj.repr(norm))
 
-                subs[name] = norm
-                for subn,subv in nsub.items():
-                    subs['%s:%s' % (name,subn)] = subv
+            subs[name] = norm
+            for subn,subv in nsub.items():
+                subs['%s:%s' % (name,subn)] = subv
 
         return self.sepr.join(reprs),subs
 

--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -304,6 +304,7 @@ class SeprType(CompType):
         CompType.__init__(self, tlib, name, **info)
         self.sepr = info.get('sep',',')
         self.lower = info.get('lower',0)
+        self.reverse = info.get('reverse',0)
 
     def norm(self, valu, oldval=None):
         reprs = []
@@ -311,7 +312,10 @@ class SeprType(CompType):
         if self.lower:
             valu = valu.lower()
 
-        parts = valu.split(self.sepr,len(self.fields))
+        if self.reverse:
+            parts = valu.rsplit(self.sepr,len(self.fields)-1)
+        else:
+            parts = valu.split(self.sepr,len(self.fields)-1)
         for part,(name,tobj) in self._zipvals(parts):
             reprs.append( tobj.repr(tobj.parse(part)) )
         return self.sepr.join(reprs)
@@ -321,7 +325,10 @@ class SeprType(CompType):
 
     def chop(self, valu):
         subs = {}
-        parts = valu.split(self.sepr,len(self.fields))
+        if self.reverse:
+            parts = valu.rsplit(self.sepr,len(self.fields)-1)
+        else:
+            parts = valu.split(self.sepr,len(self.fields)-1)
 
         if self.lower:
             valu = valu.lower()

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -342,3 +342,12 @@ class DataTypesTest(SynTest):
         with s_cortex.openurl('ram:///') as core:
             core.addType('foo:bar',subof='inet:ipv4')
             self.assertIsNotNone( core.getTypeInfo('foo:bar','ex') )
+
+    def test_type_sepr_reverse(self):
+        tlib = s_types.TypeLib()
+
+        tlib.addType('foo',subof='sepr',sep='/',fields='first,str:lwr|rest,str:lwr',reverse=1)
+        foo = tlib.getTypeChop('foo','/home/user/Downloads')
+        self.eq( foo[1].get('first'), '/home/user' )
+        self.eq( foo[1].get('rest'), 'downloads' )
+

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -369,25 +369,3 @@ class DataTypesTest(SynTest):
 
         self.assertRaises( BadTypeValu, tlib.getTypeChop, 'path', 'some-filename' )
 
-    def test_type_sepr_strictfields(self):
-        tlib = s_types.TypeLib()
-
-        tlib.addType('foo',subof='sepr',sep='.',fields='a,str:lwr|b,str:lwr')
-        foo = tlib.getTypeChop('foo', 'AAA.BBB')
-        self.eq( foo[1].get('a'), 'aaa' )
-        self.eq( foo[1].get('b'), 'bbb' )
-        self.eq( tlib.getTypeNorm('foo', 'AAA.BBB'), 'aaa.bbb' )
-
-        self.assertRaises( BadTypeValu, tlib.getTypeChop, 'foo', 'AAABBB' )
-
-        tlib.addType('bar',subof='sepr',sep='.',fields='a,str:lwr|b,str:lwr', strictfields=0)
-        bar = tlib.getTypeChop('bar', 'AAA.BBB')
-        self.eq( bar[1].get('a'), 'aaa' )
-        self.eq( bar[1].get('b'), 'bbb' )
-        self.eq( tlib.getTypeNorm('bar', 'AAA.BBB'), 'aaa.bbb')
-
-        bar2 = tlib.getTypeChop('bar', 'AAABBB')
-        self.eq( bar2[1].get('a'), 'aaabbb' )
-        self.eq( bar2[1].get('b'), None )
-        self.eq( tlib.getTypeNorm('bar', 'AAABBB'), 'aaabbb')
-

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -369,3 +369,25 @@ class DataTypesTest(SynTest):
 
         self.assertRaises( BadTypeValu, tlib.getTypeChop, 'path', 'some-filename' )
 
+    def test_type_sepr_strictfields(self):
+        tlib = s_types.TypeLib()
+
+        tlib.addType('foo',subof='sepr',sep='.',fields='a,str:lwr|b,str:lwr')
+        foo = tlib.getTypeChop('foo', 'AAA.BBB')
+        self.eq( foo[1].get('a'), 'aaa' )
+        self.eq( foo[1].get('b'), 'bbb' )
+        self.eq( tlib.getTypeNorm('foo', 'AAA.BBB'), 'aaa.bbb' )
+
+        self.assertRaises( BadTypeValu, tlib.getTypeChop, 'foo', 'AAABBB' )
+
+        tlib.addType('bar',subof='sepr',sep='.',fields='a,str:lwr|b,str:lwr', strictfields=0)
+        bar = tlib.getTypeChop('bar', 'AAA.BBB')
+        self.eq( bar[1].get('a'), 'aaa' )
+        self.eq( bar[1].get('b'), 'bbb' )
+        self.eq( tlib.getTypeNorm('bar', 'AAA.BBB'), 'aaa.bbb')
+
+        bar2 = tlib.getTypeChop('bar', 'AAABBB')
+        self.eq( bar2[1].get('a'), 'aaabbb' )
+        self.eq( bar2[1].get('b'), None )
+        self.eq( tlib.getTypeNorm('bar', 'AAABBB'), 'aaabbb')
+

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -351,3 +351,21 @@ class DataTypesTest(SynTest):
         self.eq( foo[1].get('first'), '/home/user' )
         self.eq( foo[1].get('rest'), 'downloads' )
 
+    def test_type_comp_recursive(self):
+        tlib = s_types.TypeLib()
+
+        tlib.addType('path',subof='sepr',sep='/',fields='dirname,path|filename,str:lwr',recursive=1,reverse=1)
+        foo = tlib.getTypeChop('path','/home/user/Downloads')
+        self.eq( foo[1].get('dirname'), '/home/user' )
+        self.eq( foo[1].get('filename'), 'downloads' )
+
+        foo2 = tlib.getTypeChop('path','/home')
+        self.eq( foo2[1].get('dirname'), '' )
+        self.eq( foo2[1].get('filename'), 'home' )
+
+        foo3 = tlib.getTypeChop('path','/')
+        self.eq( foo3[1].get('dirname'), '' )
+        self.eq( foo3[1].get('filename'), '' )
+
+        self.assertRaises( BadTypeValu, tlib.getTypeChop, 'path', 'some-filename' )
+

--- a/synapse/tests/test_types.py
+++ b/synapse/tests/test_types.py
@@ -354,7 +354,7 @@ class DataTypesTest(SynTest):
     def test_type_comp_recursive(self):
         tlib = s_types.TypeLib()
 
-        tlib.addType('path',subof='sepr',sep='/',fields='dirname,path|filename,str:lwr',recursive=1,reverse=1)
+        tlib.addType('path',subof='sepr',sep='/',fields='dirname,path|filename,str:lwr',reverse=1)
         foo = tlib.getTypeChop('path','/home/user/Downloads')
         self.eq( foo[1].get('dirname'), '/home/user' )
         self.eq( foo[1].get('filename'), 'downloads' )


### PR DESCRIPTION
this PR sits on top of #108, so consider that one first.

here we add support for recursive comp types. that is, a subprop of a comp type may be an instance of that comp type. i've updated `SeprType` to support recursion. this means you can do something like:

```
>>> tlib.addType('path',
                 subof='sepr',
                 sep='/',
                 reverse=1,
                 fields='dirname,path|filename,str:lwr',
                 recursive=1)
>>> tlib.getTypeChop('path','/home/user/Downloads')

<<<
('/home/user/downloads',
  {
    'dirname': '/home/user',
    'filename': 'downloads',
  })
```

there's possible a number of applications for this (fqdn, file paths, etc.), so i hope its worth the increased complexity within `SeprType`.

~~also adds the `strictfields` option to `SeprType`. by default, this option is set. when it is unset, then missing propvalues are not set, and no `BadPropValu` exception is raised. this makes it easy to parse strings with an optional suffix. for example:~~

```
>>> tlib.addType('filename',
                 subof='sepr',
                 sep='.',
                 reverse=1,
                 strictfields=0,
                 fields='basename,str:lwr|ext,str:lwr')
>>> tlib.getTypeChop('filename','kernel32.dll')

<<<
('kernel32.dll',
  {
    'basename': 'kernel32',
    'ext': '.dll',
  })

>>> # look, no error!
>>> tlib.getTypeChop('filename','Downloads')

<<<
('Downloads',
  {
    'basename': 'downloads',
  })
```