### PR TITLE
types: fix syn:prop regex to support globs

### DIFF
--- a/synapse/lib/types.py
+++ b/synapse/lib/types.py
@@ -395,7 +395,7 @@ class TypeLib:
 
         # add base synapse types
         self.addType('syn:tag',subof='str', regex=r'^([\w]+\.)*[\w]+$', lower=1)
-        self.addType('syn:prop',subof='str', regex=r'^([\w]+:)*[\w]+$', lower=1)
+        self.addType('syn:prop',subof='str', regex=r'^([\w]+:)*([\w]+|\*)$', lower=1)
         self.addType('syn:type',subof='str', regex=r'^([\w]+:)*[\w]+$', lower=1)
         self.addType('syn:glob',subof='str', regex=r'^([\w]+:)*[\w]+:\*$', lower=1)
 


### PR DESCRIPTION
this enables glob props from data models. currently, there's an error thrown.